### PR TITLE
use `extra-bundled-libraries` for verilated FFI code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           apt-get install sbt -y
       - name: Build clash-vexriscv
         run: |
-          # export PKG_CONFIG_PATH=/opt/share/pkgconfig/:${PKG_CONFIG_PATH}
+          export PKG_CONFIG_PATH=/opt/share/pkgconfig/:${PKG_CONFIG_PATH}
           cabal build clash-vexriscv
       - name: Build clash-vexriscv-sim
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,7 @@ packages:
 write-ghc-environment-files: always
 
 with-compiler: ghc-9.0.2
+executable-dynamic: True
 
 tests: True
 

--- a/clash-vexriscv/Makefile
+++ b/clash-vexriscv/Makefile
@@ -13,17 +13,19 @@ VERILATOR_FLAGS = -CFLAGS '-O3 -fPIC' -Wno-fatal +1364-2001ext+v
 VERILATOR_CFLAGS = $(shell pkg-config --cflags verilator)
 FFI_CPPFLAGS = $(VERILATOR_CFLAGS) -fPIC -O3 -I$(VERILATOR_DIR)
 
-all: $(OUT_DIR)/libVexRiscvFFI.a
+all: $(OUT_DIR)/libVexRiscvFFI.a $(OUT_DIR)/libVexRiscvFFI.so
 
 clean:
 	rm $(VERILATOR_DIR) -rf
 	rm $(CPU_DIR)/VexRiscv.v -rf
 	rm $(OUT_DIR) -rf
 
-$(OUT_DIR)/VexRiscv.v: $(CPU_DIR)/src/main/scala/example/ExampleCpu.scala
+$(CPU_DIR)/VexRiscv.v: $(CPU_DIR)/src/main/scala/example/ExampleCpu.scala
 	cd $(CPU_DIR); sbt "runMain example.ExampleCpu"
+
+$(OUT_DIR)/VexRiscv.v: $(CPU_DIR)/VexRiscv.v
 	mkdir -p $(OUT_DIR)
-	mv $(CPU_DIR)/VexRiscv.v $(OUT_DIR)/VexRiscv.v
+	cp $(CPU_DIR)/VexRiscv.v $(OUT_DIR)/VexRiscv.v
 
 $(VERILATOR_DIR)/VVexRiscv.mk $(VERILATOR_DIR)/VVexRiscv.h: $(OUT_DIR)/VexRiscv.v
 	cd $(OUT_DIR); verilator $(VERILATOR_FLAGS) --cc -Mdir ../$(VERILATOR_DIR) VexRiscv.v
@@ -37,10 +39,21 @@ $(OUT_DIR)/impl.o: $(FFI_DIR)/impl.cpp $(FFI_DIR)/interface.h
 $(OUT_DIR)/verilated.o: $(shell pkg-config --variable=includedir verilator)/verilated.cpp
 	$(CXX) $(FFI_CPPFLAGS) -c $(shell pkg-config --variable=includedir verilator)/verilated.cpp -o $(OUT_DIR)/verilated.o
 
-$(OUT_DIR)/libVexRiscvFFI.a: $(VERILATOR_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/impl.o $(OUT_DIR)/verilated.o
+$(OUT_DIR)/VVexRiscv__ALL.a: $(VERILATOR_DIR)/VVexRiscv__ALL.a
+	cp $(VERILATOR_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/VVexRiscv__ALL.a
+
+$(OUT_DIR)/libVexRiscvFFI.a: $(OUT_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/impl.o $(OUT_DIR)/verilated.o
 	rm -f $(OUT_DIR)/libVexRiscvFFI.a
 	ar rcsT \
 		$(OUT_DIR)/libVexRiscvFFI.a \
 		$(OUT_DIR)/impl.o \
-		$(VERILATOR_DIR)/VVexRiscv__ALL.a \
+		$(OUT_DIR)/VVexRiscv__ALL.a \
 		$(OUT_DIR)/verilated.o
+
+
+$(OUT_DIR)/libVexRiscvFFI.so: $(OUT_DIR)/libVexRiscvFFI.a
+	rm -f $(OUT_DIR)/libVexRiscvFFI.so
+	$(CXX) -shared -o $(OUT_DIR)/libVexRiscvFFI.so \
+		-Wl,--whole-archive \
+			$(OUT_DIR)/libVexRiscvFFI.a \
+		-Wl,--no-whole-archive

--- a/clash-vexriscv/Setup.hs
+++ b/clash-vexriscv/Setup.hs
@@ -9,13 +9,15 @@ import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Setup
 import Distribution.Simple.Utils
 import System.Directory
+import System.FilePath ((</>))
 
 main :: IO ()
 main =
   defaultMainWithHooks
     simpleUserHooks
-      { preConf = makeExtLib,
-        confHook = \a f -> confHook simpleUserHooks a f >>= updateExtraLibDirs
+      { preConf = makeExtLib
+      , confHook = \a f -> confHook simpleUserHooks a f >>= updateExtraLibDirs
+      , copyHook = \desc lbi h f -> copyHook simpleUserHooks desc lbi h f >> copyVexRiscvFfiLib desc lbi f
       }
 
 makeExtLib :: Args -> ConfigFlags -> IO HookedBuildInfo
@@ -32,20 +34,45 @@ updateExtraLibDirs localBuildInfo = do
   let packageDescription = localPkgDescr localBuildInfo
       lib = fromJust $ library packageDescription
       libBuild = libBuildInfo lib
+      libBuildDir = buildDir localBuildInfo
+
   dir <- getCurrentDirectory
-  return
-    localBuildInfo
-      { localPkgDescr =
-          packageDescription
-            { library =
-                Just $
-                  lib
-                    { libBuildInfo =
-                        libBuild
-                          { extraLibDirs =
-                              (dir ++ "/build_out_dir") :
-                              extraLibDirs libBuild
-                          }
-                    }
-            }
-      }
+
+  let tmpPath file = dir </> "build_out_dir" </> file
+      finalPath file = libBuildDir </> file
+  
+  -- when using `extra-bundled-libraries`, cabal seems to get confused
+  -- and needs multiple versions of the library at different points
+  -- during compilation
+  copyFile (tmpPath "libVexRiscvFFI.so") (finalPath "libVexRiscvFFI.so")
+  copyFile (tmpPath "libVexRiscvFFI.so") (finalPath "libCVexRiscvFFI.so")
+  copyFile (tmpPath "libVexRiscvFFI.so") (finalPath "libCVexRiscvFFI-ghc9.0.2.so")
+  
+  copyFile (tmpPath "libVexRiscvFFI.a") (finalPath "libCVexRiscvFFI.a")
+
+  pure localBuildInfo
+
+
+copyVexRiscvFfiLib :: PackageDescription -> LocalBuildInfo -> CopyFlags -> IO ()
+copyVexRiscvFfiLib pkgDescr lbi flags = do
+  let
+    libBuildDir0 = buildDir lbi
+    libPref = libdir . absoluteInstallDirs pkgDescr lbi
+              . fromFlag . copyDest
+              $ flags
+
+  libBuildDir <- makeAbsolute libBuildDir0
+
+  createDirectoryIfMissing True libPref
+
+  let
+    tmpPath file = libBuildDir </> file
+    finalPath file = libPref </> file
+  
+  -- when using `extra-bundled-libraries`, cabal seems to get confused
+  -- and needs multiple versions of the library at different points
+  -- during compilation
+  copyFile (tmpPath "libVexRiscvFFI.so") (finalPath "libVexRiscvFFI.so")
+  copyFile (tmpPath "libCVexRiscvFFI.so") (finalPath "libCVexRiscvFFI.so")
+  copyFile (tmpPath "libCVexRiscvFFI-ghc9.0.2.so") (finalPath "libCVexRiscvFFI-ghc9.0.2.so")
+  copyFile (tmpPath "libCVexRiscvFFI.a") (finalPath "libCVexRiscvFFI.a")

--- a/clash-vexriscv/clash-vexriscv.cabal
+++ b/clash-vexriscv/clash-vexriscv.cabal
@@ -9,12 +9,30 @@ Copyright:           Copyright © 2022 Google LLC
 build-type:          Custom
 
 data-files:
+  example-cpu/VexRiscv.v
+
+extra-tmp-files:
   build_out_dir/VexRiscv.v
+
+extra-source-files:
+  -- FFI code
+  src/ffi/impl.cpp
+  src/ffi/interface.h
+
+  -- Scala VexRiscv CPU code
+  example-cpu/project/build.properties
+  example-cpu/project/Dependencies.scala
+  example-cpu/src/main/scala/example/ExampleCpu.scala
+  example-cpu/lib/vexriscv_2.11-2.0.0.jar
+  example-cpu/lib/vexriscv_2.11-2.0.0.jar.license
+  example-cpu/build.sbt
+  Makefile
 
 custom-setup
   setup-depends:
     base,
     Cabal,
+    filepath,
     directory
 
 common common-options
@@ -86,6 +104,7 @@ library
   exposed-modules:
     VexRiscv
     VexRiscv.FFI
+    VexRiscv.TH
   build-depends:
     base,
     clash-prelude,
@@ -96,6 +115,7 @@ library
     filepath,
     containers,
     string-interpolate,
-    template-haskell
-  extra-libraries: VexRiscvFFI, stdc++
+    template-haskell,
+    Glob,
+  extra-bundled-libraries: CVexRiscvFFI
   include-dirs: src/

--- a/clash-vexriscv/example-cpu/.gitignore
+++ b/clash-vexriscv/example-cpu/.gitignore
@@ -4,4 +4,3 @@
 
 /.bsp/
 target/
-VexRiscv.v

--- a/clash-vexriscv/example-cpu/VexRiscv.v
+++ b/clash-vexriscv/example-cpu/VexRiscv.v
@@ -1,0 +1,4474 @@
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
+// Component : VexRiscv
+// Git hash  : edd4d371d58f877a0c8feda07445fd2254a4b31f
+
+`timescale 1ns/1ps
+
+module VexRiscv (
+  input               timerInterrupt,
+  input               externalInterrupt,
+  input               softwareInterrupt,
+  output              iBusWishbone_CYC,
+  output              iBusWishbone_STB,
+  input               iBusWishbone_ACK,
+  output              iBusWishbone_WE,
+  output     [29:0]   iBusWishbone_ADR,
+  input      [31:0]   iBusWishbone_DAT_MISO,
+  output     [31:0]   iBusWishbone_DAT_MOSI,
+  output     [3:0]    iBusWishbone_SEL,
+  input               iBusWishbone_ERR,
+  output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
+  output              dBusWishbone_CYC,
+  output              dBusWishbone_STB,
+  input               dBusWishbone_ACK,
+  output              dBusWishbone_WE,
+  output     [29:0]   dBusWishbone_ADR,
+  input      [31:0]   dBusWishbone_DAT_MISO,
+  output     [31:0]   dBusWishbone_DAT_MOSI,
+  output reg [3:0]    dBusWishbone_SEL,
+  input               dBusWishbone_ERR,
+  output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
+  input               clk,
+  input               reset
+);
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_EBREAK = 2'd2;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
+  wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_decode_FORMAL_PC_NEXT;
+  wire       [2:0]    _zz_decode_FORMAL_PC_NEXT_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire                _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_1;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_2;
+  wire       [31:0]   _zz_IBusSimplePlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusSimplePlugin_fetchPc_pc_1;
+  wire       [31:0]   _zz_IBusSimplePlugin_decodePc_pcPlus;
+  wire       [2:0]    _zz_IBusSimplePlugin_decodePc_pcPlus_1;
+  wire       [31:0]   _zz_IBusSimplePlugin_decompressor_decompressed_27;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_28;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_29;
+  wire       [6:0]    _zz_IBusSimplePlugin_decompressor_decompressed_30;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_31;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_32;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_33;
+  wire       [11:0]   _zz_IBusSimplePlugin_decompressor_decompressed_34;
+  wire       [11:0]   _zz_IBusSimplePlugin_decompressor_decompressed_35;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next_1;
+  wire       [0:0]    _zz_IBusSimplePlugin_pending_next_2;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next_3;
+  wire       [0:0]    _zz_IBusSimplePlugin_pending_next_4;
+  wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter;
+  wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1;
+  wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2;
+  wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3;
+  wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_1;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_2;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_3;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_4;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_5;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_6;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_7;
+  wire       [2:0]    _zz__zz_decode_BRANCH_CTRL_2_8;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_9;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_10;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_11;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_12;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_13;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_14;
+  wire       [23:0]   _zz__zz_decode_BRANCH_CTRL_2_15;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_16;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_17;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_18;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_19;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_20;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_21;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_22;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_23;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_24;
+  wire       [20:0]   _zz__zz_decode_BRANCH_CTRL_2_25;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_26;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_27;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_28;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_29;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_30;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_31;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_32;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_33;
+  wire       [16:0]   _zz__zz_decode_BRANCH_CTRL_2_34;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_35;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_36;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_37;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_38;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_39;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_40;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_41;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_42;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_43;
+  wire       [13:0]   _zz__zz_decode_BRANCH_CTRL_2_44;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_45;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_46;
+  wire       [1:0]    _zz__zz_decode_BRANCH_CTRL_2_47;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_48;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_49;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_50;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_51;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_52;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_53;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_54;
+  wire       [2:0]    _zz__zz_decode_BRANCH_CTRL_2_55;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_56;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_57;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_58;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_59;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_60;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_61;
+  wire       [1:0]    _zz__zz_decode_BRANCH_CTRL_2_62;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_63;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_64;
+  wire       [9:0]    _zz__zz_decode_BRANCH_CTRL_2_65;
+  wire       [5:0]    _zz__zz_decode_BRANCH_CTRL_2_66;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_67;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_68;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_69;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_70;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_71;
+  wire       [2:0]    _zz__zz_decode_BRANCH_CTRL_2_72;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_73;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_74;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_75;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_76;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_77;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_78;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_79;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_80;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_81;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_82;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_83;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_84;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_85;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_86;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_87;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_88;
+  wire       [6:0]    _zz__zz_decode_BRANCH_CTRL_2_89;
+  wire       [1:0]    _zz__zz_decode_BRANCH_CTRL_2_90;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_91;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_92;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_93;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_94;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_95;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_96;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_97;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_98;
+  wire       [3:0]    _zz__zz_decode_BRANCH_CTRL_2_99;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_100;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_101;
+  wire       [1:0]    _zz__zz_decode_BRANCH_CTRL_2_102;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_103;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_104;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_105;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_106;
+  wire       [3:0]    _zz__zz_decode_BRANCH_CTRL_2_107;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_108;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_109;
+  wire       [0:0]    _zz__zz_decode_BRANCH_CTRL_2_110;
+  wire       [2:0]    _zz__zz_decode_BRANCH_CTRL_2_111;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_112;
+  wire       [31:0]   _zz__zz_decode_BRANCH_CTRL_2_113;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_114;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_115;
+  wire       [1:0]    _zz__zz_decode_BRANCH_CTRL_2_116;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_117;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_118;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_119;
+  wire                _zz__zz_decode_BRANCH_CTRL_2_120;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_decode_SRC1_1;
+  wire       [4:0]    _zz__zz_decode_SRC1_1_1;
+  wire       [11:0]   _zz__zz_decode_SRC2_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_lastStageRegFileWrite_payload_data;
+  wire       [31:0]   _zz__zz_lastStageRegFileWrite_payload_data_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
+  wire       [32:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire       [51:0]   memory_MUL_LOW;
+  wire       [31:0]   memory_MEMORY_READ_DATA;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
+  wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   decode_SRC2;
+  wire       [31:0]   decode_SRC1;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire       [31:0]   decode_RS2;
+  wire       [31:0]   decode_RS1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
+  wire                decode_IS_CSR;
+  wire                decode_MEMORY_STORE;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire                decode_MEMORY_ENABLE;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire       [31:0]   writeBack_FORMAL_PC_NEXT;
+  wire       [31:0]   memory_FORMAL_PC_NEXT;
+  wire       [31:0]   execute_FORMAL_PC_NEXT;
+  wire       [31:0]   decode_FORMAL_PC_NEXT;
+  wire       [31:0]   memory_PC;
+  wire       [31:0]   memory_BRANCH_CALC;
+  wire                memory_BRANCH_DO;
+  wire       [31:0]   execute_PC;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
+  wire                decode_RS2_USE;
+  wire                decode_RS1_USE;
+  wire                execute_REGFILE_WRITE_VALID;
+  wire                execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                memory_REGFILE_WRITE_VALID;
+  wire                memory_BYPASSABLE_MEMORY_STAGE;
+  wire                writeBack_REGFILE_WRITE_VALID;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
+  wire                execute_IS_RS1_SIGNED;
+  wire                execute_IS_DIV;
+  wire                execute_IS_RS2_SIGNED;
+  reg        [31:0]   _zz_memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire       [31:0]   memory_INSTRUCTION;
+  wire                memory_IS_DIV;
+  wire                writeBack_IS_MUL;
+  wire       [33:0]   writeBack_MUL_HH;
+  wire       [51:0]   writeBack_MUL_LOW;
+  wire       [33:0]   memory_MUL_HL;
+  wire       [33:0]   memory_MUL_LH;
+  wire       [31:0]   memory_MUL_LL;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
+  wire                execute_SRC_LESS_UNSIGNED;
+  wire                execute_SRC2_FORCE_ZERO;
+  wire                execute_SRC_USE_SUB_LESS;
+  wire       [31:0]   _zz_decode_SRC2;
+  wire       [31:0]   _zz_decode_SRC2_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [31:0]   _zz_decode_SRC1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire                decode_SRC_USE_SUB_LESS;
+  wire                decode_SRC_ADD_ZERO;
+  wire       [31:0]   execute_SRC_ADD_SUB;
+  wire                execute_SRC_LESS;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
+  wire       [31:0]   execute_SRC2;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
+  wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
+  reg                 decode_REGFILE_WRITE_VALID;
+  wire                decode_LEGAL_INSTRUCTION;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA;
+  wire       [31:0]   execute_SRC1;
+  wire                execute_CSR_READ_OPCODE;
+  wire                execute_CSR_WRITE_OPCODE;
+  wire                execute_IS_CSR;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
+  reg        [31:0]   _zz_lastStageRegFileWrite_payload_data;
+  wire                writeBack_MEMORY_ENABLE;
+  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   writeBack_MEMORY_READ_DATA;
+  wire                memory_ALIGNEMENT_FAULT;
+  wire       [31:0]   memory_REGFILE_WRITE_DATA;
+  wire                memory_MEMORY_STORE;
+  wire                memory_MEMORY_ENABLE;
+  wire       [31:0]   execute_SRC_ADD;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
+  wire       [31:0]   execute_INSTRUCTION;
+  wire                execute_MEMORY_STORE;
+  wire                execute_MEMORY_ENABLE;
+  wire                execute_ALIGNEMENT_FAULT;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  wire       [31:0]   decode_PC;
+  wire       [31:0]   decode_INSTRUCTION;
+  wire                decode_IS_RVC;
+  wire       [31:0]   writeBack_PC;
+  wire       [31:0]   writeBack_INSTRUCTION;
+  wire                decode_arbitration_haltItself;
+  reg                 decode_arbitration_haltByOther;
+  reg                 decode_arbitration_removeIt;
+  wire                decode_arbitration_flushIt;
+  reg                 decode_arbitration_flushNext;
+  reg                 decode_arbitration_isValid;
+  wire                decode_arbitration_isStuck;
+  wire                decode_arbitration_isStuckByOthers;
+  wire                decode_arbitration_isFlushed;
+  wire                decode_arbitration_isMoving;
+  wire                decode_arbitration_isFiring;
+  reg                 execute_arbitration_haltItself;
+  wire                execute_arbitration_haltByOther;
+  reg                 execute_arbitration_removeIt;
+  wire                execute_arbitration_flushIt;
+  reg                 execute_arbitration_flushNext;
+  reg                 execute_arbitration_isValid;
+  wire                execute_arbitration_isStuck;
+  wire                execute_arbitration_isStuckByOthers;
+  wire                execute_arbitration_isFlushed;
+  wire                execute_arbitration_isMoving;
+  wire                execute_arbitration_isFiring;
+  reg                 memory_arbitration_haltItself;
+  wire                memory_arbitration_haltByOther;
+  reg                 memory_arbitration_removeIt;
+  wire                memory_arbitration_flushIt;
+  reg                 memory_arbitration_flushNext;
+  reg                 memory_arbitration_isValid;
+  wire                memory_arbitration_isStuck;
+  wire                memory_arbitration_isStuckByOthers;
+  wire                memory_arbitration_isFlushed;
+  wire                memory_arbitration_isMoving;
+  wire                memory_arbitration_isFiring;
+  wire                writeBack_arbitration_haltItself;
+  wire                writeBack_arbitration_haltByOther;
+  reg                 writeBack_arbitration_removeIt;
+  wire                writeBack_arbitration_flushIt;
+  reg                 writeBack_arbitration_flushNext;
+  reg                 writeBack_arbitration_isValid;
+  wire                writeBack_arbitration_isStuck;
+  wire                writeBack_arbitration_isStuckByOthers;
+  wire                writeBack_arbitration_isFlushed;
+  wire                writeBack_arbitration_isMoving;
+  wire                writeBack_arbitration_isFiring;
+  wire       [31:0]   lastStageInstruction /* verilator public */ ;
+  wire       [31:0]   lastStagePc /* verilator public */ ;
+  wire                lastStageIsValid /* verilator public */ ;
+  wire                lastStageIsFiring /* verilator public */ ;
+  reg                 IBusSimplePlugin_fetcherHalt;
+  wire                IBusSimplePlugin_forceNoDecodeCond;
+  reg                 IBusSimplePlugin_incomingInstruction;
+  wire                IBusSimplePlugin_pcValids_0;
+  wire                IBusSimplePlugin_pcValids_1;
+  wire                IBusSimplePlugin_pcValids_2;
+  wire                IBusSimplePlugin_pcValids_3;
+  wire                iBus_cmd_valid;
+  reg                 iBus_cmd_ready;
+  wire       [31:0]   iBus_cmd_payload_pc;
+  wire                iBus_rsp_valid;
+  wire                iBus_rsp_payload_error;
+  wire       [31:0]   iBus_rsp_payload_inst;
+  wire                IBusSimplePlugin_decodeExceptionPort_valid;
+  reg        [3:0]    IBusSimplePlugin_decodeExceptionPort_payload_code;
+  wire       [31:0]   IBusSimplePlugin_decodeExceptionPort_payload_badAddr;
+  reg                 DBusSimplePlugin_memoryExceptionPort_valid;
+  reg        [3:0]    DBusSimplePlugin_memoryExceptionPort_payload_code;
+  wire       [31:0]   DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
+  wire                CsrPlugin_inWfi /* verilator public */ ;
+  wire                CsrPlugin_thirdPartyWake;
+  reg                 CsrPlugin_jumpInterface_valid;
+  reg        [31:0]   CsrPlugin_jumpInterface_payload;
+  wire                CsrPlugin_exceptionPendings_0;
+  wire                CsrPlugin_exceptionPendings_1;
+  wire                CsrPlugin_exceptionPendings_2;
+  wire                CsrPlugin_exceptionPendings_3;
+  wire                contextSwitching;
+  reg        [1:0]    CsrPlugin_privilege;
+  wire                CsrPlugin_forceMachineWire;
+  reg                 CsrPlugin_selfException_valid;
+  reg        [3:0]    CsrPlugin_selfException_payload_code;
+  wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
+  wire                CsrPlugin_allowInterrupts;
+  wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
+  wire                decodeExceptionPort_valid;
+  wire       [3:0]    decodeExceptionPort_payload_code;
+  wire       [31:0]   decodeExceptionPort_payload_badAddr;
+  wire                BranchPlugin_jumpInterface_valid;
+  wire       [31:0]   BranchPlugin_jumpInterface_payload;
+  wire                BranchPlugin_inDebugNoFetchFlag;
+  wire                IBusSimplePlugin_externalFlush;
+  wire                IBusSimplePlugin_jump_pcLoad_valid;
+  wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload;
+  wire                IBusSimplePlugin_fetchPc_output_valid;
+  wire                IBusSimplePlugin_fetchPc_output_ready;
+  wire       [31:0]   IBusSimplePlugin_fetchPc_output_payload;
+  reg        [31:0]   IBusSimplePlugin_fetchPc_pcReg /* verilator public */ ;
+  reg                 IBusSimplePlugin_fetchPc_correction;
+  reg                 IBusSimplePlugin_fetchPc_correctionReg;
+  wire                IBusSimplePlugin_fetchPc_output_fire;
+  wire                IBusSimplePlugin_fetchPc_corrected;
+  reg                 IBusSimplePlugin_fetchPc_pcRegPropagate;
+  reg                 IBusSimplePlugin_fetchPc_booted;
+  reg                 IBusSimplePlugin_fetchPc_inc;
+  wire                when_Fetcher_l134;
+  wire                IBusSimplePlugin_fetchPc_output_fire_1;
+  wire                when_Fetcher_l134_1;
+  reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
+  reg                 IBusSimplePlugin_fetchPc_flushed;
+  wire                when_Fetcher_l161;
+  reg                 IBusSimplePlugin_decodePc_flushed;
+  reg        [31:0]   IBusSimplePlugin_decodePc_pcReg /* verilator public */ ;
+  wire       [31:0]   IBusSimplePlugin_decodePc_pcPlus;
+  wire                IBusSimplePlugin_decodePc_injectedDecode;
+  wire                when_Fetcher_l183;
+  wire                when_Fetcher_l195;
+  wire                IBusSimplePlugin_iBusRsp_redoFetch;
+  wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
+  wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_0_input_payload;
+  wire                IBusSimplePlugin_iBusRsp_stages_0_output_valid;
+  wire                IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_0_output_payload;
+  reg                 IBusSimplePlugin_iBusRsp_stages_0_halt;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_input_valid;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_input_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_1_input_payload;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_output_valid;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_output_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_1_output_payload;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_halt;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready;
+  wire                IBusSimplePlugin_iBusRsp_flush;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
+  reg                 IBusSimplePlugin_iBusRsp_readyForError;
+  wire                IBusSimplePlugin_iBusRsp_output_valid;
+  wire                IBusSimplePlugin_iBusRsp_output_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_output_payload_pc;
+  wire                IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
+  wire                IBusSimplePlugin_iBusRsp_output_payload_isRvc;
+  wire                IBusSimplePlugin_decompressor_input_valid;
+  wire                IBusSimplePlugin_decompressor_input_ready;
+  wire       [31:0]   IBusSimplePlugin_decompressor_input_payload_pc;
+  wire                IBusSimplePlugin_decompressor_input_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_decompressor_input_payload_rsp_inst;
+  wire                IBusSimplePlugin_decompressor_input_payload_isRvc;
+  wire                IBusSimplePlugin_decompressor_output_valid;
+  wire                IBusSimplePlugin_decompressor_output_ready;
+  wire       [31:0]   IBusSimplePlugin_decompressor_output_payload_pc;
+  wire                IBusSimplePlugin_decompressor_output_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_decompressor_output_payload_rsp_inst;
+  wire                IBusSimplePlugin_decompressor_output_payload_isRvc;
+  wire                IBusSimplePlugin_decompressor_flushNext;
+  wire                IBusSimplePlugin_decompressor_consumeCurrent;
+  reg                 IBusSimplePlugin_decompressor_bufferValid;
+  reg        [15:0]   IBusSimplePlugin_decompressor_bufferData;
+  wire                IBusSimplePlugin_decompressor_isInputLowRvc;
+  wire                IBusSimplePlugin_decompressor_isInputHighRvc;
+  reg                 IBusSimplePlugin_decompressor_throw2BytesReg;
+  wire                IBusSimplePlugin_decompressor_throw2Bytes;
+  wire                IBusSimplePlugin_decompressor_unaligned;
+  reg                 IBusSimplePlugin_decompressor_bufferValidLatch;
+  reg                 IBusSimplePlugin_decompressor_throw2BytesLatch;
+  wire                IBusSimplePlugin_decompressor_bufferValidPatched;
+  wire                IBusSimplePlugin_decompressor_throw2BytesPatched;
+  wire       [31:0]   IBusSimplePlugin_decompressor_raw;
+  wire                IBusSimplePlugin_decompressor_isRvc;
+  wire       [15:0]   _zz_IBusSimplePlugin_decompressor_decompressed;
+  reg        [31:0]   IBusSimplePlugin_decompressor_decompressed;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_1;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_2;
+  wire       [11:0]   _zz_IBusSimplePlugin_decompressor_decompressed_3;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_4;
+  reg        [11:0]   _zz_IBusSimplePlugin_decompressor_decompressed_5;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_6;
+  reg        [9:0]    _zz_IBusSimplePlugin_decompressor_decompressed_7;
+  wire       [20:0]   _zz_IBusSimplePlugin_decompressor_decompressed_8;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_9;
+  reg        [14:0]   _zz_IBusSimplePlugin_decompressor_decompressed_10;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_11;
+  reg        [2:0]    _zz_IBusSimplePlugin_decompressor_decompressed_12;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_13;
+  reg        [9:0]    _zz_IBusSimplePlugin_decompressor_decompressed_14;
+  wire       [20:0]   _zz_IBusSimplePlugin_decompressor_decompressed_15;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_16;
+  reg        [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_17;
+  wire       [12:0]   _zz_IBusSimplePlugin_decompressor_decompressed_18;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_19;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_20;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_21;
+  wire       [4:0]    switch_Misc_l44;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_22;
+  wire       [1:0]    switch_Misc_l210;
+  wire       [1:0]    switch_Misc_l210_1;
+  reg        [2:0]    _zz_IBusSimplePlugin_decompressor_decompressed_23;
+  reg        [2:0]    _zz_IBusSimplePlugin_decompressor_decompressed_24;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_25;
+  reg        [6:0]    _zz_IBusSimplePlugin_decompressor_decompressed_26;
+  wire                IBusSimplePlugin_decompressor_output_fire;
+  wire                IBusSimplePlugin_decompressor_bufferFill;
+  wire                when_Fetcher_l286;
+  wire                when_Fetcher_l289;
+  wire                when_Fetcher_l294;
+  wire                IBusSimplePlugin_injector_decodeInput_valid;
+  wire                IBusSimplePlugin_injector_decodeInput_ready;
+  wire       [31:0]   IBusSimplePlugin_injector_decodeInput_payload_pc;
+  wire                IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  wire                IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_valid;
+  reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_pc;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l332;
+  reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l332_1;
+  reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l332_2;
+  reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l332_3;
+  reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
+  wire                IBusSimplePlugin_cmd_valid;
+  wire                IBusSimplePlugin_cmd_ready;
+  wire       [31:0]   IBusSimplePlugin_cmd_payload_pc;
+  wire                IBusSimplePlugin_pending_inc;
+  wire                IBusSimplePlugin_pending_dec;
+  reg        [2:0]    IBusSimplePlugin_pending_value;
+  wire       [2:0]    IBusSimplePlugin_pending_next;
+  wire                IBusSimplePlugin_cmdFork_canEmit;
+  wire                when_IBusSimplePlugin_l305;
+  wire                IBusSimplePlugin_cmd_fire;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_output_valid;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_output_ready;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
+  reg        [2:0]    IBusSimplePlugin_rspJoin_rspBuffer_discardCounter;
+  wire                iBus_rsp_toStream_valid;
+  wire                iBus_rsp_toStream_ready;
+  wire                iBus_rsp_toStream_payload_error;
+  wire       [31:0]   iBus_rsp_toStream_payload_inst;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_flush;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_pc;
+  reg                 IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
+  wire                IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
+  wire                when_IBusSimplePlugin_l376;
+  wire                IBusSimplePlugin_rspJoin_join_valid;
+  wire                IBusSimplePlugin_rspJoin_join_ready;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_pc;
+  wire                IBusSimplePlugin_rspJoin_join_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
+  wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
+  reg                 IBusSimplePlugin_rspJoin_exceptionDetected;
+  wire                IBusSimplePlugin_rspJoin_join_fire;
+  wire                IBusSimplePlugin_rspJoin_join_fire_1;
+  wire                _zz_IBusSimplePlugin_iBusRsp_output_valid;
+  wire                when_IBusSimplePlugin_l402;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [1:0]    dBus_cmd_payload_size;
+  wire                dBus_rsp_ready;
+  wire                dBus_rsp_error;
+  wire       [31:0]   dBus_rsp_data;
+  wire                _zz_dBus_cmd_valid;
+  reg                 execute_DBusSimplePlugin_skipCmd;
+  reg        [31:0]   _zz_dBus_cmd_payload_data;
+  wire                when_DBusSimplePlugin_l428;
+  reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
+  wire       [3:0]    execute_DBusSimplePlugin_formalMask;
+  wire                when_DBusSimplePlugin_l482;
+  wire                when_DBusSimplePlugin_l489;
+  wire                when_DBusSimplePlugin_l515;
+  reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
+  wire       [1:0]    switch_Misc_l210_2;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
+  reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
+  wire                when_DBusSimplePlugin_l558;
+  wire       [1:0]    CsrPlugin_misa_base;
+  wire       [25:0]   CsrPlugin_misa_extensions;
+  reg        [1:0]    CsrPlugin_mtvec_mode;
+  reg        [29:0]   CsrPlugin_mtvec_base;
+  reg        [31:0]   CsrPlugin_mepc;
+  reg                 CsrPlugin_mstatus_MIE;
+  reg                 CsrPlugin_mstatus_MPIE;
+  reg        [1:0]    CsrPlugin_mstatus_MPP;
+  reg                 CsrPlugin_mip_MEIP;
+  reg                 CsrPlugin_mip_MTIP;
+  reg                 CsrPlugin_mip_MSIP;
+  reg                 CsrPlugin_mie_MEIE;
+  reg                 CsrPlugin_mie_MTIE;
+  reg                 CsrPlugin_mie_MSIE;
+  reg                 CsrPlugin_mcause_interrupt;
+  reg        [3:0]    CsrPlugin_mcause_exceptionCode;
+  reg        [31:0]   CsrPlugin_mtval;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+  reg                 CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+  wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
+  wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
+  reg                 CsrPlugin_interrupt_valid;
+  reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
+  reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
+  wire                CsrPlugin_exception;
+  wire                CsrPlugin_lastStageWasWfi;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_0;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_1;
+  reg                 CsrPlugin_pipelineLiberator_pcValids_2;
+  wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
+  reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l1004;
+  wire                CsrPlugin_interruptJump /* verilator public */ ;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
+  reg        [1:0]    CsrPlugin_targetPrivilege;
+  reg        [3:0]    CsrPlugin_trapCause;
+  reg        [1:0]    CsrPlugin_xtvec_mode;
+  reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
+  reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1129;
+  wire                execute_CsrPlugin_blockedBySideEffects;
+  reg                 execute_CsrPlugin_illegalAccess;
+  reg                 execute_CsrPlugin_illegalInstruction;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1167;
+  reg                 execute_CsrPlugin_writeInstruction;
+  reg                 execute_CsrPlugin_readInstruction;
+  wire                execute_CsrPlugin_writeEnable;
+  wire                execute_CsrPlugin_readEnable;
+  wire       [31:0]   execute_CsrPlugin_readToWriteData;
+  wire                switch_Misc_l210_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
+  wire       [11:0]   execute_CsrPlugin_csrAddress;
+  wire       [29:0]   _zz_decode_BRANCH_CTRL_2;
+  wire                _zz_decode_BRANCH_CTRL_3;
+  wire                _zz_decode_BRANCH_CTRL_4;
+  wire                _zz_decode_BRANCH_CTRL_5;
+  wire                _zz_decode_BRANCH_CTRL_6;
+  wire                _zz_decode_BRANCH_CTRL_7;
+  wire                _zz_decode_BRANCH_CTRL_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_9;
+  wire                when_RegFilePlugin_l63;
+  wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
+  wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
+  wire       [31:0]   decode_RegFilePlugin_rs1Data;
+  wire       [31:0]   decode_RegFilePlugin_rs2Data;
+  reg                 lastStageRegFileWrite_valid /* verilator public */ ;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_2;
+  reg        [31:0]   execute_IntAluPlugin_bitwise;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_decode_SRC1_1;
+  wire                _zz_decode_SRC2_2;
+  reg        [19:0]   _zz_decode_SRC2_3;
+  wire                _zz_decode_SRC2_4;
+  reg        [19:0]   _zz_decode_SRC2_5;
+  reg        [31:0]   _zz_decode_SRC2_6;
+  reg        [31:0]   execute_SrcPlugin_addSub;
+  wire                execute_SrcPlugin_less;
+  reg                 execute_MulPlugin_aSigned;
+  reg                 execute_MulPlugin_bSigned;
+  wire       [31:0]   execute_MulPlugin_a;
+  wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
+  wire       [15:0]   execute_MulPlugin_aULow;
+  wire       [15:0]   execute_MulPlugin_bULow;
+  wire       [16:0]   execute_MulPlugin_aSLow;
+  wire       [16:0]   execute_MulPlugin_bSLow;
+  wire       [16:0]   execute_MulPlugin_aHigh;
+  wire       [16:0]   execute_MulPlugin_bHigh;
+  wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
+  reg        [32:0]   memory_DivPlugin_rs1;
+  reg        [31:0]   memory_DivPlugin_rs2;
+  reg        [64:0]   memory_DivPlugin_accumulator;
+  wire                memory_DivPlugin_frontendOk;
+  reg                 memory_DivPlugin_div_needRevert;
+  reg                 memory_DivPlugin_div_counter_willIncrement;
+  reg                 memory_DivPlugin_div_counter_willClear;
+  reg        [5:0]    memory_DivPlugin_div_counter_valueNext;
+  reg        [5:0]    memory_DivPlugin_div_counter_value;
+  wire                memory_DivPlugin_div_counter_willOverflowIfInc;
+  wire                memory_DivPlugin_div_counter_willOverflow;
+  reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
+  reg        [31:0]   memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
+  wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
+  wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
+  reg                 execute_LightShifterPlugin_isActive;
+  wire                execute_LightShifterPlugin_isShift;
+  reg        [4:0]    execute_LightShifterPlugin_amplitudeReg;
+  wire       [4:0]    execute_LightShifterPlugin_amplitude;
+  wire       [31:0]   execute_LightShifterPlugin_shiftInput;
+  wire                execute_LightShifterPlugin_done;
+  wire                when_ShiftPlugins_l169;
+  reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
+  wire                when_ShiftPlugins_l175;
+  wire                when_ShiftPlugins_l184;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l59;
+  wire                when_HazardSimplePlugin_l62;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l59_1;
+  wire                when_HazardSimplePlugin_l62_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l59_2;
+  wire                when_HazardSimplePlugin_l62_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
+  wire                execute_BranchPlugin_eq;
+  wire       [2:0]    switch_Misc_l210_4;
+  reg                 _zz_execute_BRANCH_DO;
+  reg                 _zz_execute_BRANCH_DO_1;
+  wire       [31:0]   execute_BranchPlugin_branch_src1;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
+  reg        [31:0]   _zz_execute_BranchPlugin_branch_src2_6;
+  wire       [31:0]   execute_BranchPlugin_branch_src2;
+  wire       [31:0]   execute_BranchPlugin_branchAdder;
+  wire                when_Pipeline_l124;
+  reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
+  reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
+  reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_10;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_11;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_17;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_20;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_21;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
+  reg                 decode_to_execute_MEMORY_STORE;
+  wire                when_Pipeline_l124_23;
+  reg                 execute_to_memory_MEMORY_STORE;
+  wire                when_Pipeline_l124_24;
+  reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_25;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_26;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_27;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_28;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_29;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_30;
+  reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_31;
+  reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_32;
+  reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_33;
+  reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_34;
+  reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_35;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_36;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_37;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_38;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_39;
+  reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_40;
+  reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_41;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_42;
+  reg        [31:0]   decode_to_execute_SRC1;
+  wire                when_Pipeline_l124_43;
+  reg        [31:0]   decode_to_execute_SRC2;
+  wire                when_Pipeline_l124_44;
+  reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  wire                when_Pipeline_l124_45;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_46;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_47;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_48;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_49;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_50;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_51;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_52;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_53;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_54;
+  reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_55;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_56;
+  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  wire                when_Pipeline_l124_57;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1277;
+  reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1277_1;
+  reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1277_2;
+  reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1277_3;
+  reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1277_4;
+  reg                 execute_CsrPlugin_csr_834;
+  wire       [1:0]    switch_CsrPlugin_l723;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
+  wire                iBus_cmd_m2sPipe_valid;
+  wire                iBus_cmd_m2sPipe_ready;
+  wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
+  reg                 iBus_cmd_rValid;
+  reg        [31:0]   iBus_cmd_rData_pc;
+  wire                when_Stream_l368;
+  wire                dBus_cmd_halfPipe_valid;
+  wire                dBus_cmd_halfPipe_ready;
+  wire                dBus_cmd_halfPipe_payload_wr;
+  wire       [31:0]   dBus_cmd_halfPipe_payload_address;
+  wire       [31:0]   dBus_cmd_halfPipe_payload_data;
+  wire       [1:0]    dBus_cmd_halfPipe_payload_size;
+  reg                 dBus_cmd_rValid;
+  wire                dBus_cmd_halfPipe_fire;
+  reg                 dBus_cmd_rData_wr;
+  reg        [31:0]   dBus_cmd_rData_address;
+  reg        [31:0]   dBus_cmd_rData_data;
+  reg        [1:0]    dBus_cmd_rData_size;
+  reg        [3:0]    _zz_dBusWishbone_SEL;
+  wire                when_DBusSimplePlugin_l189;
+  `ifndef SYNTHESIS
+  reg [31:0] decode_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
+  reg [47:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [47:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [47:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [47:0] _zz_execute_to_memory_ENV_CTRL_1_string;
+  reg [47:0] decode_ENV_CTRL_string;
+  reg [47:0] _zz_decode_ENV_CTRL_string;
+  reg [47:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [47:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
+  reg [31:0] execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [71:0] execute_SHIFT_CTRL_string;
+  reg [71:0] _zz_execute_SHIFT_CTRL_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [63:0] execute_ALU_CTRL_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [39:0] execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [71:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [39:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [47:0] _zz_decode_ENV_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
+  reg [47:0] memory_ENV_CTRL_string;
+  reg [47:0] _zz_memory_ENV_CTRL_string;
+  reg [47:0] execute_ENV_CTRL_string;
+  reg [47:0] _zz_execute_ENV_CTRL_string;
+  reg [47:0] writeBack_ENV_CTRL_string;
+  reg [47:0] _zz_writeBack_ENV_CTRL_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [47:0] _zz_decode_ENV_CTRL_2_string;
+  reg [39:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_9_string;
+  reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [47:0] decode_to_execute_ENV_CTRL_string;
+  reg [47:0] execute_to_memory_ENV_CTRL_string;
+  reg [47:0] memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
+  `endif
+
+  reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+
+  assign _zz_when = ({decodeExceptionPort_valid,IBusSimplePlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_decode_FORMAL_PC_NEXT_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_decode_FORMAL_PC_NEXT = {29'd0, _zz_decode_FORMAL_PC_NEXT_1};
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_1 = (_zz_IBusSimplePlugin_jump_pcLoad_payload & (~ _zz_IBusSimplePlugin_jump_pcLoad_payload_2));
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_2 = (_zz_IBusSimplePlugin_jump_pcLoad_payload - 2'b01);
+  assign _zz_IBusSimplePlugin_fetchPc_pc_1 = {IBusSimplePlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusSimplePlugin_fetchPc_pc = {29'd0, _zz_IBusSimplePlugin_fetchPc_pc_1};
+  assign _zz_IBusSimplePlugin_decodePc_pcPlus_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_IBusSimplePlugin_decodePc_pcPlus = {29'd0, _zz_IBusSimplePlugin_decodePc_pcPlus_1};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_27 = {{_zz_IBusSimplePlugin_decompressor_decompressed_10,_zz_IBusSimplePlugin_decompressor_decompressed[6 : 2]},12'h0};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_34 = {{{4'b0000,_zz_IBusSimplePlugin_decompressor_decompressed[8 : 7]},_zz_IBusSimplePlugin_decompressor_decompressed[12 : 9]},2'b00};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_35 = {{{4'b0000,_zz_IBusSimplePlugin_decompressor_decompressed[8 : 7]},_zz_IBusSimplePlugin_decompressor_decompressed[12 : 9]},2'b00};
+  assign _zz_IBusSimplePlugin_pending_next = (IBusSimplePlugin_pending_value + _zz_IBusSimplePlugin_pending_next_1);
+  assign _zz_IBusSimplePlugin_pending_next_2 = IBusSimplePlugin_pending_inc;
+  assign _zz_IBusSimplePlugin_pending_next_1 = {2'd0, _zz_IBusSimplePlugin_pending_next_2};
+  assign _zz_IBusSimplePlugin_pending_next_4 = IBusSimplePlugin_pending_dec;
+  assign _zz_IBusSimplePlugin_pending_next_3 = {2'd0, _zz_IBusSimplePlugin_pending_next_4};
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1 = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000));
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter = {2'd0, _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1};
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3 = IBusSimplePlugin_pending_dec;
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2 = {2'd0, _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3};
+  assign _zz_DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_decode_SRC1_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz__zz_decode_SRC1_1_1 = decode_INSTRUCTION[19 : 15];
+  assign _zz__zz_decode_SRC2_4 = {decode_INSTRUCTION[31 : 25],decode_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_lastStageRegFileWrite_payload_data = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_lastStageRegFileWrite_payload_data_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,_zz_decode_LEGAL_INSTRUCTION_16}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00100073);
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_28 = (_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10] == 2'b01);
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_29 = ((_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10] == 2'b11) && (_zz_IBusSimplePlugin_decompressor_decompressed[6 : 5] == 2'b00));
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_30 = 7'h0;
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_31 = _zz_IBusSimplePlugin_decompressor_decompressed[6 : 2];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_32 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_33 = _zz_IBusSimplePlugin_decompressor_decompressed[11 : 7];
+  assign _zz__zz_decode_BRANCH_CTRL_2 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_BRANCH_CTRL_2_1 = 32'h00000004;
+  assign _zz__zz_decode_BRANCH_CTRL_2_2 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_BRANCH_CTRL_2_3 = 32'h00000040;
+  assign _zz__zz_decode_BRANCH_CTRL_2_4 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_5) == 32'h00005010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_6 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_7) == 32'h00005020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_8 = {(_zz__zz_decode_BRANCH_CTRL_2_9 == _zz__zz_decode_BRANCH_CTRL_2_10),{_zz__zz_decode_BRANCH_CTRL_2_11,_zz__zz_decode_BRANCH_CTRL_2_12}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_13 = (|_zz_decode_BRANCH_CTRL_8);
+  assign _zz__zz_decode_BRANCH_CTRL_2_14 = (|_zz_decode_BRANCH_CTRL_8);
+  assign _zz__zz_decode_BRANCH_CTRL_2_15 = {(|_zz__zz_decode_BRANCH_CTRL_2_16),{_zz__zz_decode_BRANCH_CTRL_2_17,{_zz__zz_decode_BRANCH_CTRL_2_19,_zz__zz_decode_BRANCH_CTRL_2_25}}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_5 = 32'h00007034;
+  assign _zz__zz_decode_BRANCH_CTRL_2_7 = 32'h02007064;
+  assign _zz__zz_decode_BRANCH_CTRL_2_9 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_BRANCH_CTRL_2_10 = 32'h40001010;
+  assign _zz__zz_decode_BRANCH_CTRL_2_11 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_12 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_16 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_17 = (|((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_18) == 32'h02000030));
+  assign _zz__zz_decode_BRANCH_CTRL_2_19 = (|{_zz__zz_decode_BRANCH_CTRL_2_20,{_zz__zz_decode_BRANCH_CTRL_2_21,_zz__zz_decode_BRANCH_CTRL_2_23}});
+  assign _zz__zz_decode_BRANCH_CTRL_2_25 = {(|_zz__zz_decode_BRANCH_CTRL_2_26),{(|_zz__zz_decode_BRANCH_CTRL_2_27),{_zz__zz_decode_BRANCH_CTRL_2_29,{_zz__zz_decode_BRANCH_CTRL_2_32,_zz__zz_decode_BRANCH_CTRL_2_34}}}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_18 = 32'h02004074;
+  assign _zz__zz_decode_BRANCH_CTRL_2_20 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_BRANCH_CTRL_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_22) == 32'h00001010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_23 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_24) == 32'h00001010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_26 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_BRANCH_CTRL_2_27 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_28) == 32'h00002000);
+  assign _zz__zz_decode_BRANCH_CTRL_2_29 = (|{_zz__zz_decode_BRANCH_CTRL_2_30,_zz__zz_decode_BRANCH_CTRL_2_31});
+  assign _zz__zz_decode_BRANCH_CTRL_2_32 = (|_zz__zz_decode_BRANCH_CTRL_2_33);
+  assign _zz__zz_decode_BRANCH_CTRL_2_34 = {(|_zz__zz_decode_BRANCH_CTRL_2_35),{_zz__zz_decode_BRANCH_CTRL_2_36,{_zz__zz_decode_BRANCH_CTRL_2_41,_zz__zz_decode_BRANCH_CTRL_2_44}}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_22 = 32'h00003034;
+  assign _zz__zz_decode_BRANCH_CTRL_2_24 = 32'h02003054;
+  assign _zz__zz_decode_BRANCH_CTRL_2_28 = 32'h00003000;
+  assign _zz__zz_decode_BRANCH_CTRL_2_30 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_BRANCH_CTRL_2_31 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_BRANCH_CTRL_2_33 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
+  assign _zz__zz_decode_BRANCH_CTRL_2_35 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
+  assign _zz__zz_decode_BRANCH_CTRL_2_36 = (|{(_zz__zz_decode_BRANCH_CTRL_2_37 == _zz__zz_decode_BRANCH_CTRL_2_38),(_zz__zz_decode_BRANCH_CTRL_2_39 == _zz__zz_decode_BRANCH_CTRL_2_40)});
+  assign _zz__zz_decode_BRANCH_CTRL_2_41 = (|{_zz__zz_decode_BRANCH_CTRL_2_42,_zz__zz_decode_BRANCH_CTRL_2_43});
+  assign _zz__zz_decode_BRANCH_CTRL_2_44 = {(|{_zz__zz_decode_BRANCH_CTRL_2_45,_zz__zz_decode_BRANCH_CTRL_2_47}),{(|_zz__zz_decode_BRANCH_CTRL_2_50),{_zz__zz_decode_BRANCH_CTRL_2_52,{_zz__zz_decode_BRANCH_CTRL_2_60,_zz__zz_decode_BRANCH_CTRL_2_65}}}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_37 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_BRANCH_CTRL_2_38 = 32'h00001050;
+  assign _zz__zz_decode_BRANCH_CTRL_2_39 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_BRANCH_CTRL_2_40 = 32'h00002050;
+  assign _zz__zz_decode_BRANCH_CTRL_2_42 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_43 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_45 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_46) == 32'h00000040);
+  assign _zz__zz_decode_BRANCH_CTRL_2_47 = {_zz_decode_BRANCH_CTRL_4,(_zz__zz_decode_BRANCH_CTRL_2_48 == _zz__zz_decode_BRANCH_CTRL_2_49)};
+  assign _zz__zz_decode_BRANCH_CTRL_2_50 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_51) == 32'h00000020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_52 = (|{_zz__zz_decode_BRANCH_CTRL_2_53,{_zz__zz_decode_BRANCH_CTRL_2_54,_zz__zz_decode_BRANCH_CTRL_2_55}});
+  assign _zz__zz_decode_BRANCH_CTRL_2_60 = (|{_zz__zz_decode_BRANCH_CTRL_2_61,_zz__zz_decode_BRANCH_CTRL_2_62});
+  assign _zz__zz_decode_BRANCH_CTRL_2_65 = {(|_zz__zz_decode_BRANCH_CTRL_2_66),{_zz__zz_decode_BRANCH_CTRL_2_81,{_zz__zz_decode_BRANCH_CTRL_2_84,_zz__zz_decode_BRANCH_CTRL_2_89}}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_46 = 32'h00000050;
+  assign _zz__zz_decode_BRANCH_CTRL_2_48 = (decode_INSTRUCTION & 32'h00003040);
+  assign _zz__zz_decode_BRANCH_CTRL_2_49 = 32'h00000040;
+  assign _zz__zz_decode_BRANCH_CTRL_2_51 = 32'h00000020;
+  assign _zz__zz_decode_BRANCH_CTRL_2_53 = ((decode_INSTRUCTION & 32'h00000040) == 32'h00000040);
+  assign _zz__zz_decode_BRANCH_CTRL_2_54 = _zz_decode_BRANCH_CTRL_5;
+  assign _zz__zz_decode_BRANCH_CTRL_2_55 = {(_zz__zz_decode_BRANCH_CTRL_2_56 == _zz__zz_decode_BRANCH_CTRL_2_57),{_zz_decode_BRANCH_CTRL_7,_zz__zz_decode_BRANCH_CTRL_2_58}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_61 = _zz_decode_BRANCH_CTRL_5;
+  assign _zz__zz_decode_BRANCH_CTRL_2_62 = {_zz_decode_BRANCH_CTRL_7,(_zz__zz_decode_BRANCH_CTRL_2_63 == _zz__zz_decode_BRANCH_CTRL_2_64)};
+  assign _zz__zz_decode_BRANCH_CTRL_2_66 = {_zz_decode_BRANCH_CTRL_6,{_zz__zz_decode_BRANCH_CTRL_2_67,{_zz__zz_decode_BRANCH_CTRL_2_69,_zz__zz_decode_BRANCH_CTRL_2_72}}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_81 = (|{_zz_decode_BRANCH_CTRL_5,_zz__zz_decode_BRANCH_CTRL_2_82});
+  assign _zz__zz_decode_BRANCH_CTRL_2_84 = (|{_zz__zz_decode_BRANCH_CTRL_2_85,_zz__zz_decode_BRANCH_CTRL_2_86});
+  assign _zz__zz_decode_BRANCH_CTRL_2_89 = {(|_zz__zz_decode_BRANCH_CTRL_2_90),{_zz__zz_decode_BRANCH_CTRL_2_95,{_zz__zz_decode_BRANCH_CTRL_2_98,_zz__zz_decode_BRANCH_CTRL_2_107}}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_56 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_57 = 32'h00004020;
+  assign _zz__zz_decode_BRANCH_CTRL_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_59) == 32'h00000020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_63 = (decode_INSTRUCTION & 32'h02000060);
+  assign _zz__zz_decode_BRANCH_CTRL_2_64 = 32'h00000020;
+  assign _zz__zz_decode_BRANCH_CTRL_2_67 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_68) == 32'h00001010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_69 = (_zz__zz_decode_BRANCH_CTRL_2_70 == _zz__zz_decode_BRANCH_CTRL_2_71);
+  assign _zz__zz_decode_BRANCH_CTRL_2_72 = {_zz__zz_decode_BRANCH_CTRL_2_73,{_zz__zz_decode_BRANCH_CTRL_2_75,_zz__zz_decode_BRANCH_CTRL_2_78}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_82 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_83) == 32'h00000020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_85 = _zz_decode_BRANCH_CTRL_5;
+  assign _zz__zz_decode_BRANCH_CTRL_2_86 = (_zz__zz_decode_BRANCH_CTRL_2_87 == _zz__zz_decode_BRANCH_CTRL_2_88);
+  assign _zz__zz_decode_BRANCH_CTRL_2_90 = {_zz__zz_decode_BRANCH_CTRL_2_91,_zz__zz_decode_BRANCH_CTRL_2_93};
+  assign _zz__zz_decode_BRANCH_CTRL_2_95 = (|_zz__zz_decode_BRANCH_CTRL_2_96);
+  assign _zz__zz_decode_BRANCH_CTRL_2_98 = (|_zz__zz_decode_BRANCH_CTRL_2_99);
+  assign _zz__zz_decode_BRANCH_CTRL_2_107 = {_zz__zz_decode_BRANCH_CTRL_2_108,{_zz__zz_decode_BRANCH_CTRL_2_110,_zz__zz_decode_BRANCH_CTRL_2_116}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_59 = 32'h02000020;
+  assign _zz__zz_decode_BRANCH_CTRL_2_68 = 32'h00001010;
+  assign _zz__zz_decode_BRANCH_CTRL_2_70 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_71 = 32'h00002010;
+  assign _zz__zz_decode_BRANCH_CTRL_2_73 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_74) == 32'h00000010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_75 = (_zz__zz_decode_BRANCH_CTRL_2_76 == _zz__zz_decode_BRANCH_CTRL_2_77);
+  assign _zz__zz_decode_BRANCH_CTRL_2_78 = (_zz__zz_decode_BRANCH_CTRL_2_79 == _zz__zz_decode_BRANCH_CTRL_2_80);
+  assign _zz__zz_decode_BRANCH_CTRL_2_83 = 32'h00000070;
+  assign _zz__zz_decode_BRANCH_CTRL_2_87 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_BRANCH_CTRL_2_88 = 32'h0;
+  assign _zz__zz_decode_BRANCH_CTRL_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_92) == 32'h00006010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_93 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_94) == 32'h00004010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_96 = ((decode_INSTRUCTION & _zz__zz_decode_BRANCH_CTRL_2_97) == 32'h00002010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_99 = {_zz__zz_decode_BRANCH_CTRL_2_100,{_zz__zz_decode_BRANCH_CTRL_2_101,_zz__zz_decode_BRANCH_CTRL_2_102}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_108 = (|_zz__zz_decode_BRANCH_CTRL_2_109);
+  assign _zz__zz_decode_BRANCH_CTRL_2_110 = (|_zz__zz_decode_BRANCH_CTRL_2_111);
+  assign _zz__zz_decode_BRANCH_CTRL_2_116 = {_zz__zz_decode_BRANCH_CTRL_2_117,_zz__zz_decode_BRANCH_CTRL_2_119};
+  assign _zz__zz_decode_BRANCH_CTRL_2_74 = 32'h00000050;
+  assign _zz__zz_decode_BRANCH_CTRL_2_76 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_BRANCH_CTRL_2_77 = 32'h00000004;
+  assign _zz__zz_decode_BRANCH_CTRL_2_79 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_BRANCH_CTRL_2_80 = 32'h0;
+  assign _zz__zz_decode_BRANCH_CTRL_2_92 = 32'h00006014;
+  assign _zz__zz_decode_BRANCH_CTRL_2_94 = 32'h00005014;
+  assign _zz__zz_decode_BRANCH_CTRL_2_97 = 32'h00006014;
+  assign _zz__zz_decode_BRANCH_CTRL_2_100 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_BRANCH_CTRL_2_101 = _zz_decode_BRANCH_CTRL_4;
+  assign _zz__zz_decode_BRANCH_CTRL_2_102 = {(_zz__zz_decode_BRANCH_CTRL_2_103 == _zz__zz_decode_BRANCH_CTRL_2_104),(_zz__zz_decode_BRANCH_CTRL_2_105 == _zz__zz_decode_BRANCH_CTRL_2_106)};
+  assign _zz__zz_decode_BRANCH_CTRL_2_109 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz__zz_decode_BRANCH_CTRL_2_111 = {(_zz__zz_decode_BRANCH_CTRL_2_112 == _zz__zz_decode_BRANCH_CTRL_2_113),{_zz__zz_decode_BRANCH_CTRL_2_114,_zz__zz_decode_BRANCH_CTRL_2_115}};
+  assign _zz__zz_decode_BRANCH_CTRL_2_117 = (|{_zz__zz_decode_BRANCH_CTRL_2_118,_zz_decode_BRANCH_CTRL_3});
+  assign _zz__zz_decode_BRANCH_CTRL_2_119 = (|{_zz__zz_decode_BRANCH_CTRL_2_120,_zz_decode_BRANCH_CTRL_3});
+  assign _zz__zz_decode_BRANCH_CTRL_2_103 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_BRANCH_CTRL_2_104 = 32'h00002000;
+  assign _zz__zz_decode_BRANCH_CTRL_2_105 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_BRANCH_CTRL_2_106 = 32'h00001000;
+  assign _zz__zz_decode_BRANCH_CTRL_2_112 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_BRANCH_CTRL_2_113 = 32'h00000040;
+  assign _zz__zz_decode_BRANCH_CTRL_2_114 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_BRANCH_CTRL_2_115 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_BRANCH_CTRL_2_118 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_BRANCH_CTRL_2_120 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_1) begin
+      RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
+    end
+  end
+
+  StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c (
+    .io_push_valid         (iBus_rsp_toStream_valid                                       ), //i
+    .io_push_ready         (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready            ), //o
+    .io_push_payload_error (iBus_rsp_toStream_payload_error                               ), //i
+    .io_push_payload_inst  (iBus_rsp_toStream_payload_inst[31:0]                          ), //i
+    .io_pop_valid          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid             ), //o
+    .io_pop_ready          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready             ), //i
+    .io_pop_payload_error  (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error     ), //o
+    .io_pop_payload_inst   (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]), //o
+    .io_flush              (1'b0                                                          ), //i
+    .io_occupancy          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy             ), //o
+    .clk                   (clk                                                           ), //i
+    .reset                 (reset                                                         )  //i
+  );
+  `ifndef SYNTHESIS
+  always @(*) begin
+    case(decode_BRANCH_CTRL)
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
+      default : decode_BRANCH_CTRL_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_BRANCH_CTRL)
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SHIFT_CTRL)
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : _zz_decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_memory_to_writeBack_ENV_CTRL_string = "EBREAK";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_memory_to_writeBack_ENV_CTRL_1_string = "EBREAK";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_execute_to_memory_ENV_CTRL)
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_execute_to_memory_ENV_CTRL_string = "EBREAK";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_execute_to_memory_ENV_CTRL_1_string = "EBREAK";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ENV_CTRL)
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : decode_ENV_CTRL_string = "EBREAK";
+      default : decode_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ENV_CTRL)
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_decode_ENV_CTRL_string = "EBREAK";
+      default : _zz_decode_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_ENV_CTRL)
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_decode_to_execute_ENV_CTRL_string = "EBREAK";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_decode_to_execute_ENV_CTRL_1_string = "EBREAK";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ALU_CTRL)
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_ALU_CTRL)
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
+      default : execute_BRANCH_CTRL_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_execute_BRANCH_CTRL)
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_SHIFT_CTRL)
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_execute_SHIFT_CTRL)
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : _zz_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SRC2_CTRL)
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SRC1_CTRL)
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_ALU_CTRL)
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      default : execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_execute_ALU_CTRL)
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_ALU_BITWISE_CTRL)
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_BRANCH_CTRL_1)
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SHIFT_CTRL_1)
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ENV_CTRL_1)
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_decode_ENV_CTRL_1_string = "EBREAK";
+      default : _zz_decode_ENV_CTRL_1_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SRC2_CTRL_1)
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ALU_CTRL_1)
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SRC1_CTRL_1)
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_ENV_CTRL)
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : memory_ENV_CTRL_string = "EBREAK";
+      default : memory_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_memory_ENV_CTRL)
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_memory_ENV_CTRL_string = "EBREAK";
+      default : _zz_memory_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_ENV_CTRL)
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : execute_ENV_CTRL_string = "EBREAK";
+      default : execute_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_execute_ENV_CTRL)
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_execute_ENV_CTRL_string = "EBREAK";
+      default : _zz_execute_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(writeBack_ENV_CTRL)
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : writeBack_ENV_CTRL_string = "EBREAK";
+      default : writeBack_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_writeBack_ENV_CTRL)
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_writeBack_ENV_CTRL_string = "EBREAK";
+      default : _zz_writeBack_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SRC1_CTRL_2)
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ALU_CTRL_2)
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SRC2_CTRL_2)
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ENV_CTRL_2)
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE  ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : _zz_decode_ENV_CTRL_2_string = "EBREAK";
+      default : _zz_decode_ENV_CTRL_2_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_SHIFT_CTRL_2)
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_decode_BRANCH_CTRL_9)
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_9_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_9_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_9_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_9_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_9_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_CTRL)
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ENV_CTRL)
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : decode_to_execute_ENV_CTRL_string = "EBREAK";
+      default : decode_to_execute_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_ENV_CTRL)
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : execute_to_memory_ENV_CTRL_string = "EBREAK";
+      default : execute_to_memory_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_to_writeBack_ENV_CTRL)
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE  ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET  ";
+      EnvCtrlEnum_EBREAK : memory_to_writeBack_ENV_CTRL_string = "EBREAK";
+      default : memory_to_writeBack_ENV_CTRL_string = "??????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SHIFT_CTRL)
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_BRANCH_CTRL)
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
+    endcase
+  end
+  `endif
+
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
+  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = _zz_execute_BRANCH_DO_1;
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
+  assign decode_SRC2 = _zz_decode_SRC2_6;
+  assign decode_SRC1 = _zz_decode_SRC1_1;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_RS2 = decode_RegFilePlugin_rs2Data;
+  assign decode_RS1 = decode_RegFilePlugin_rs1Data;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_IS_RS2_SIGNED = _zz_decode_BRANCH_CTRL_2[25];
+  assign decode_IS_RS1_SIGNED = _zz_decode_BRANCH_CTRL_2[24];
+  assign decode_IS_DIV = _zz_decode_BRANCH_CTRL_2[23];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_decode_BRANCH_CTRL_2[22];
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_BRANCH_CTRL_2[18];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_BRANCH_CTRL_2[15];
+  assign decode_MEMORY_STORE = _zz_decode_BRANCH_CTRL_2[12];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_BRANCH_CTRL_2[11];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_BRANCH_CTRL_2[10];
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_MEMORY_ENABLE = _zz_decode_BRANCH_CTRL_2[3];
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
+  assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
+  assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
+  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_decode_FORMAL_PC_NEXT);
+  assign memory_PC = execute_to_memory_PC;
+  assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
+  assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
+  assign execute_PC = decode_to_execute_PC;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_BRANCH_CTRL_2[14];
+  assign decode_RS1_USE = _zz_decode_BRANCH_CTRL_2[4];
+  assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
+  assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
+  assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
+  assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
+  assign execute_IS_DIV = decode_to_execute_IS_DIV;
+  assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
+  always @(*) begin
+    _zz_memory_to_writeBack_REGFILE_WRITE_DATA = memory_REGFILE_WRITE_DATA;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_memory_to_writeBack_REGFILE_WRITE_DATA = memory_DivPlugin_div_result;
+    end
+  end
+
+  assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
+  assign memory_IS_DIV = execute_to_memory_IS_DIV;
+  assign writeBack_IS_MUL = memory_to_writeBack_IS_MUL;
+  assign writeBack_MUL_HH = memory_to_writeBack_MUL_HH;
+  assign writeBack_MUL_LOW = memory_to_writeBack_MUL_LOW;
+  assign memory_MUL_HL = execute_to_memory_MUL_HL;
+  assign memory_MUL_LH = execute_to_memory_MUL_LH;
+  assign memory_MUL_LL = execute_to_memory_MUL_LL;
+  assign execute_RS1 = decode_to_execute_RS1;
+  assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
+  assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
+  assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
+  assign _zz_decode_SRC2 = decode_PC;
+  assign _zz_decode_SRC2_1 = decode_RS2;
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_SRC1 = decode_RS1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_BRANCH_CTRL_2[2];
+  assign decode_SRC_ADD_ZERO = _zz_decode_BRANCH_CTRL_2[21];
+  assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
+  assign execute_SRC_LESS = execute_SrcPlugin_less;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = decode_to_execute_SRC2;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_decompressor_output_payload_rsp_inst);
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_BRANCH_CTRL_2[9];
+    if(when_RegFilePlugin_l63) begin
+      decode_REGFILE_WRITE_VALID = 1'b0;
+    end
+  end
+
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
+  always @(*) begin
+    _zz_execute_to_memory_REGFILE_WRITE_DATA = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1189) begin
+      _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
+    end
+    if(when_ShiftPlugins_l169) begin
+      _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
+    end
+  end
+
+  assign execute_SRC1 = decode_to_execute_SRC1;
+  assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
+  assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
+  assign execute_IS_CSR = decode_to_execute_IS_CSR;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
+  always @(*) begin
+    _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusSimplePlugin_l558) begin
+      _zz_lastStageRegFileWrite_payload_data = writeBack_DBusSimplePlugin_rspFormated;
+    end
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
+        2'b00 : begin
+          _zz_lastStageRegFileWrite_payload_data = _zz__zz_lastStageRegFileWrite_payload_data;
+        end
+        default : begin
+          _zz_lastStageRegFileWrite_payload_data = _zz__zz_lastStageRegFileWrite_payload_data_1;
+        end
+      endcase
+    end
+  end
+
+  assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
+  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_READ_DATA = memory_to_writeBack_MEMORY_READ_DATA;
+  assign memory_ALIGNEMENT_FAULT = execute_to_memory_ALIGNEMENT_FAULT;
+  assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE = execute_to_memory_MEMORY_STORE;
+  assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
+  assign execute_SRC_ADD = execute_SrcPlugin_addSub;
+  assign execute_RS2 = decode_to_execute_RS2;
+  assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
+  assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
+  assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
+  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
+    end
+  end
+
+  assign decode_PC = IBusSimplePlugin_decodePc_pcReg;
+  assign decode_INSTRUCTION = IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  assign decode_IS_RVC = IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  assign writeBack_PC = memory_to_writeBack_PC;
+  assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
+  assign decode_arbitration_haltItself = 1'b0;
+  always @(*) begin
+    decode_arbitration_haltByOther = 1'b0;
+    if(CsrPlugin_pipelineLiberator_active) begin
+      decode_arbitration_haltByOther = 1'b1;
+    end
+    if(when_CsrPlugin_l1129) begin
+      decode_arbitration_haltByOther = 1'b1;
+    end
+    if(when_HazardSimplePlugin_l113) begin
+      decode_arbitration_haltByOther = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    decode_arbitration_removeIt = 1'b0;
+    if(_zz_when) begin
+      decode_arbitration_removeIt = 1'b1;
+    end
+    if(decode_arbitration_isFlushed) begin
+      decode_arbitration_removeIt = 1'b1;
+    end
+  end
+
+  assign decode_arbitration_flushIt = 1'b0;
+  always @(*) begin
+    decode_arbitration_flushNext = 1'b0;
+    if(_zz_when) begin
+      decode_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    execute_arbitration_haltItself = 1'b0;
+    if(when_DBusSimplePlugin_l428) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CsrPlugin_l1193) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
+        execute_arbitration_haltItself = 1'b1;
+      end
+    end
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l184) begin
+        execute_arbitration_haltItself = 1'b1;
+      end
+    end
+  end
+
+  assign execute_arbitration_haltByOther = 1'b0;
+  always @(*) begin
+    execute_arbitration_removeIt = 1'b0;
+    if(CsrPlugin_selfException_valid) begin
+      execute_arbitration_removeIt = 1'b1;
+    end
+    if(execute_arbitration_isFlushed) begin
+      execute_arbitration_removeIt = 1'b1;
+    end
+  end
+
+  assign execute_arbitration_flushIt = 1'b0;
+  always @(*) begin
+    execute_arbitration_flushNext = 1'b0;
+    if(CsrPlugin_selfException_valid) begin
+      execute_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    memory_arbitration_haltItself = 1'b0;
+    if(when_DBusSimplePlugin_l482) begin
+      memory_arbitration_haltItself = 1'b1;
+    end
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
+        memory_arbitration_haltItself = 1'b1;
+      end
+    end
+  end
+
+  assign memory_arbitration_haltByOther = 1'b0;
+  always @(*) begin
+    memory_arbitration_removeIt = 1'b0;
+    if(DBusSimplePlugin_memoryExceptionPort_valid) begin
+      memory_arbitration_removeIt = 1'b1;
+    end
+    if(memory_arbitration_isFlushed) begin
+      memory_arbitration_removeIt = 1'b1;
+    end
+  end
+
+  assign memory_arbitration_flushIt = 1'b0;
+  always @(*) begin
+    memory_arbitration_flushNext = 1'b0;
+    if(DBusSimplePlugin_memoryExceptionPort_valid) begin
+      memory_arbitration_flushNext = 1'b1;
+    end
+    if(BranchPlugin_jumpInterface_valid) begin
+      memory_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  assign writeBack_arbitration_haltItself = 1'b0;
+  assign writeBack_arbitration_haltByOther = 1'b0;
+  always @(*) begin
+    writeBack_arbitration_removeIt = 1'b0;
+    if(writeBack_arbitration_isFlushed) begin
+      writeBack_arbitration_removeIt = 1'b1;
+    end
+  end
+
+  assign writeBack_arbitration_flushIt = 1'b0;
+  always @(*) begin
+    writeBack_arbitration_flushNext = 1'b0;
+    if(when_CsrPlugin_l1032) begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+    if(when_CsrPlugin_l1077) begin
+      writeBack_arbitration_flushNext = 1'b1;
+    end
+  end
+
+  assign lastStageInstruction = writeBack_INSTRUCTION;
+  assign lastStagePc = writeBack_PC;
+  assign lastStageIsValid = writeBack_arbitration_isValid;
+  assign lastStageIsFiring = writeBack_arbitration_isFiring;
+  always @(*) begin
+    IBusSimplePlugin_fetcherHalt = 1'b0;
+    if(when_CsrPlugin_l935) begin
+      IBusSimplePlugin_fetcherHalt = 1'b1;
+    end
+    if(when_CsrPlugin_l1032) begin
+      IBusSimplePlugin_fetcherHalt = 1'b1;
+    end
+    if(when_CsrPlugin_l1077) begin
+      IBusSimplePlugin_fetcherHalt = 1'b1;
+    end
+  end
+
+  assign IBusSimplePlugin_forceNoDecodeCond = 1'b0;
+  always @(*) begin
+    IBusSimplePlugin_incomingInstruction = 1'b0;
+    if(IBusSimplePlugin_iBusRsp_stages_1_input_valid) begin
+      IBusSimplePlugin_incomingInstruction = 1'b1;
+    end
+    if(IBusSimplePlugin_injector_decodeInput_valid) begin
+      IBusSimplePlugin_incomingInstruction = 1'b1;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  assign CsrPlugin_inWfi = 1'b0;
+  assign CsrPlugin_thirdPartyWake = 1'b0;
+  always @(*) begin
+    CsrPlugin_jumpInterface_valid = 1'b0;
+    if(when_CsrPlugin_l1032) begin
+      CsrPlugin_jumpInterface_valid = 1'b1;
+    end
+    if(when_CsrPlugin_l1077) begin
+      CsrPlugin_jumpInterface_valid = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1032) begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
+    end
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
+        2'b11 : begin
+          CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
+        end
+        default : begin
+        end
+      endcase
+    end
+  end
+
+  assign CsrPlugin_forceMachineWire = 1'b0;
+  assign CsrPlugin_allowInterrupts = 1'b1;
+  assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
+  assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusSimplePlugin_jump_pcLoad_valid = ({BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid} != 2'b00);
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
+  assign IBusSimplePlugin_jump_pcLoad_payload = (_zz_IBusSimplePlugin_jump_pcLoad_payload_1[0] ? CsrPlugin_jumpInterface_payload : BranchPlugin_jumpInterface_payload);
+  always @(*) begin
+    IBusSimplePlugin_fetchPc_correction = 1'b0;
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
+      IBusSimplePlugin_fetchPc_correction = 1'b1;
+    end
+  end
+
+  assign IBusSimplePlugin_fetchPc_output_fire = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
+  assign IBusSimplePlugin_fetchPc_corrected = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_correctionReg);
+  always @(*) begin
+    IBusSimplePlugin_fetchPc_pcRegPropagate = 1'b0;
+    if(IBusSimplePlugin_iBusRsp_stages_1_input_ready) begin
+      IBusSimplePlugin_fetchPc_pcRegPropagate = 1'b1;
+    end
+  end
+
+  assign when_Fetcher_l134 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
+  assign IBusSimplePlugin_fetchPc_output_fire_1 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_IBusSimplePlugin_fetchPc_pc);
+    if(IBusSimplePlugin_fetchPc_inc) begin
+      IBusSimplePlugin_fetchPc_pc[1] = 1'b0;
+    end
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
+      IBusSimplePlugin_fetchPc_pc = IBusSimplePlugin_jump_pcLoad_payload;
+    end
+    IBusSimplePlugin_fetchPc_pc[0] = 1'b0;
+  end
+
+  always @(*) begin
+    IBusSimplePlugin_fetchPc_flushed = 1'b0;
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
+      IBusSimplePlugin_fetchPc_flushed = 1'b1;
+    end
+  end
+
+  assign when_Fetcher_l161 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
+  assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
+  assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
+  always @(*) begin
+    IBusSimplePlugin_decodePc_flushed = 1'b0;
+    if(when_Fetcher_l195) begin
+      IBusSimplePlugin_decodePc_flushed = 1'b1;
+    end
+  end
+
+  assign IBusSimplePlugin_decodePc_pcPlus = (IBusSimplePlugin_decodePc_pcReg + _zz_IBusSimplePlugin_decodePc_pcPlus);
+  assign IBusSimplePlugin_decodePc_injectedDecode = 1'b0;
+  assign when_Fetcher_l183 = (decode_arbitration_isFiring && (! IBusSimplePlugin_decodePc_injectedDecode));
+  assign when_Fetcher_l195 = (IBusSimplePlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_valid = IBusSimplePlugin_fetchPc_output_valid;
+  assign IBusSimplePlugin_fetchPc_output_ready = IBusSimplePlugin_iBusRsp_stages_0_input_ready;
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_payload = IBusSimplePlugin_fetchPc_output_payload;
+  always @(*) begin
+    IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b0;
+    if(when_IBusSimplePlugin_l305) begin
+      IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
+    end
+  end
+
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_payload = IBusSimplePlugin_iBusRsp_stages_0_input_payload;
+  assign IBusSimplePlugin_iBusRsp_stages_1_halt = 1'b0;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
+  assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
+  always @(*) begin
+    IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
+    if(IBusSimplePlugin_injector_decodeInput_valid) begin
+      IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
+    end
+  end
+
+  assign IBusSimplePlugin_decompressor_input_valid = (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_iBusRsp_redoFetch));
+  assign IBusSimplePlugin_decompressor_input_payload_pc = IBusSimplePlugin_iBusRsp_output_payload_pc;
+  assign IBusSimplePlugin_decompressor_input_payload_rsp_error = IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
+  assign IBusSimplePlugin_decompressor_input_payload_rsp_inst = IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
+  assign IBusSimplePlugin_decompressor_input_payload_isRvc = IBusSimplePlugin_iBusRsp_output_payload_isRvc;
+  assign IBusSimplePlugin_iBusRsp_output_ready = IBusSimplePlugin_decompressor_input_ready;
+  assign IBusSimplePlugin_decompressor_flushNext = 1'b0;
+  assign IBusSimplePlugin_decompressor_consumeCurrent = 1'b0;
+  assign IBusSimplePlugin_decompressor_isInputLowRvc = (IBusSimplePlugin_decompressor_input_payload_rsp_inst[1 : 0] != 2'b11);
+  assign IBusSimplePlugin_decompressor_isInputHighRvc = (IBusSimplePlugin_decompressor_input_payload_rsp_inst[17 : 16] != 2'b11);
+  assign IBusSimplePlugin_decompressor_throw2Bytes = (IBusSimplePlugin_decompressor_throw2BytesReg || IBusSimplePlugin_decompressor_input_payload_pc[1]);
+  assign IBusSimplePlugin_decompressor_unaligned = (IBusSimplePlugin_decompressor_throw2Bytes || IBusSimplePlugin_decompressor_bufferValid);
+  assign IBusSimplePlugin_decompressor_bufferValidPatched = (IBusSimplePlugin_decompressor_input_valid ? IBusSimplePlugin_decompressor_bufferValid : IBusSimplePlugin_decompressor_bufferValidLatch);
+  assign IBusSimplePlugin_decompressor_throw2BytesPatched = (IBusSimplePlugin_decompressor_input_valid ? IBusSimplePlugin_decompressor_throw2Bytes : IBusSimplePlugin_decompressor_throw2BytesLatch);
+  assign IBusSimplePlugin_decompressor_raw = (IBusSimplePlugin_decompressor_bufferValidPatched ? {IBusSimplePlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusSimplePlugin_decompressor_bufferData} : {IBusSimplePlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusSimplePlugin_decompressor_throw2BytesPatched ? IBusSimplePlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusSimplePlugin_decompressor_input_payload_rsp_inst[15 : 0])});
+  assign IBusSimplePlugin_decompressor_isRvc = (IBusSimplePlugin_decompressor_raw[1 : 0] != 2'b11);
+  assign _zz_IBusSimplePlugin_decompressor_decompressed = IBusSimplePlugin_decompressor_raw[15 : 0];
+  always @(*) begin
+    IBusSimplePlugin_decompressor_decompressed = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    case(switch_Misc_l44)
+      5'h0 : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_IBusSimplePlugin_decompressor_decompressed[10 : 7]},_zz_IBusSimplePlugin_decompressor_decompressed[12 : 11]},_zz_IBusSimplePlugin_decompressor_decompressed[5]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},2'b00},5'h02},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed_2},7'h13};
+      end
+      5'h02 : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{_zz_IBusSimplePlugin_decompressor_decompressed_3,_zz_IBusSimplePlugin_decompressor_decompressed_1},3'b010},_zz_IBusSimplePlugin_decompressor_decompressed_2},7'h03};
+      end
+      5'h06 : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_3[11 : 5],_zz_IBusSimplePlugin_decompressor_decompressed_2},_zz_IBusSimplePlugin_decompressor_decompressed_1},3'b010},_zz_IBusSimplePlugin_decompressor_decompressed_3[4 : 0]},7'h23};
+      end
+      5'h08 : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{_zz_IBusSimplePlugin_decompressor_decompressed_5,_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h13};
+      end
+      5'h09 : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_8[20],_zz_IBusSimplePlugin_decompressor_decompressed_8[10 : 1]},_zz_IBusSimplePlugin_decompressor_decompressed_8[11]},_zz_IBusSimplePlugin_decompressor_decompressed_8[19 : 12]},_zz_IBusSimplePlugin_decompressor_decompressed_20},7'h6f};
+      end
+      5'h0a : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{_zz_IBusSimplePlugin_decompressor_decompressed_5,5'h0},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h13};
+      end
+      5'h0b : begin
+        IBusSimplePlugin_decompressor_decompressed = ((_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7] == 5'h02) ? {{{{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_12,_zz_IBusSimplePlugin_decompressor_decompressed[4 : 3]},_zz_IBusSimplePlugin_decompressor_decompressed[5]},_zz_IBusSimplePlugin_decompressor_decompressed[2]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},4'b0000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h13} : {{_zz_IBusSimplePlugin_decompressor_decompressed_27[31 : 12],_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h37});
+      end
+      5'h0c : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{((_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusSimplePlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusSimplePlugin_decompressor_decompressed_28 || _zz_IBusSimplePlugin_decompressor_decompressed_29)},5'h0}),(((! _zz_IBusSimplePlugin_decompressor_decompressed[11]) || _zz_IBusSimplePlugin_decompressor_decompressed_22) ? _zz_IBusSimplePlugin_decompressor_decompressed[6 : 2] : _zz_IBusSimplePlugin_decompressor_decompressed_2)},_zz_IBusSimplePlugin_decompressor_decompressed_1},_zz_IBusSimplePlugin_decompressor_decompressed_24},_zz_IBusSimplePlugin_decompressor_decompressed_1},(_zz_IBusSimplePlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
+      end
+      5'h0d : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_15[20],_zz_IBusSimplePlugin_decompressor_decompressed_15[10 : 1]},_zz_IBusSimplePlugin_decompressor_decompressed_15[11]},_zz_IBusSimplePlugin_decompressor_decompressed_15[19 : 12]},_zz_IBusSimplePlugin_decompressor_decompressed_19},7'h6f};
+      end
+      5'h0e : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_18[12],_zz_IBusSimplePlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusSimplePlugin_decompressor_decompressed_19},_zz_IBusSimplePlugin_decompressor_decompressed_1},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusSimplePlugin_decompressor_decompressed_18[11]},7'h63};
+      end
+      5'h0f : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_18[12],_zz_IBusSimplePlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusSimplePlugin_decompressor_decompressed_19},_zz_IBusSimplePlugin_decompressor_decompressed_1},3'b001},_zz_IBusSimplePlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusSimplePlugin_decompressor_decompressed_18[11]},7'h63};
+      end
+      5'h10 : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{7'h0,_zz_IBusSimplePlugin_decompressor_decompressed[6 : 2]},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h13};
+      end
+      5'h12 : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_IBusSimplePlugin_decompressor_decompressed[3 : 2]},_zz_IBusSimplePlugin_decompressor_decompressed[12]},_zz_IBusSimplePlugin_decompressor_decompressed[6 : 4]},2'b00},_zz_IBusSimplePlugin_decompressor_decompressed_21},3'b010},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h03};
+      end
+      5'h14 : begin
+        IBusSimplePlugin_decompressor_decompressed = ((_zz_IBusSimplePlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusSimplePlugin_decompressor_decompressed[6 : 2] == 5'h0) ? {{{{12'h0,_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusSimplePlugin_decompressor_decompressed[12] ? _zz_IBusSimplePlugin_decompressor_decompressed_20 : _zz_IBusSimplePlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_30,_zz_IBusSimplePlugin_decompressor_decompressed_31},(_zz_IBusSimplePlugin_decompressor_decompressed_32 ? _zz_IBusSimplePlugin_decompressor_decompressed_33 : _zz_IBusSimplePlugin_decompressor_decompressed_19)},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h33}));
+      end
+      5'h16 : begin
+        IBusSimplePlugin_decompressor_decompressed = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_34[11 : 5],_zz_IBusSimplePlugin_decompressor_decompressed[6 : 2]},_zz_IBusSimplePlugin_decompressor_decompressed_21},3'b010},_zz_IBusSimplePlugin_decompressor_decompressed_35[4 : 0]},7'h23};
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_1 = {2'b01,_zz_IBusSimplePlugin_decompressor_decompressed[9 : 7]};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_2 = {2'b01,_zz_IBusSimplePlugin_decompressor_decompressed[4 : 2]};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_3 = {{{{5'h0,_zz_IBusSimplePlugin_decompressor_decompressed[5]},_zz_IBusSimplePlugin_decompressor_decompressed[12 : 10]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},2'b00};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_4 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[11] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[10] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[9] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[8] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[7] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[6] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[5] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[4 : 0] = _zz_IBusSimplePlugin_decompressor_decompressed[6 : 2];
+  end
+
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_6 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[9] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[8] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[7] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[6] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[5] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[4] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[3] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[2] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[1] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[0] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+  end
+
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_8 = {{{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_7,_zz_IBusSimplePlugin_decompressor_decompressed[8]},_zz_IBusSimplePlugin_decompressor_decompressed[10 : 9]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},_zz_IBusSimplePlugin_decompressor_decompressed[7]},_zz_IBusSimplePlugin_decompressor_decompressed[2]},_zz_IBusSimplePlugin_decompressor_decompressed[11]},_zz_IBusSimplePlugin_decompressor_decompressed[5 : 3]},1'b0};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_9 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[14] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[13] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[12] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[11] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[10] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[9] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[8] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[7] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[6] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[5] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[4] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[3] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[2] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[1] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[0] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+  end
+
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_11 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusSimplePlugin_decompressor_decompressed_12[2] = _zz_IBusSimplePlugin_decompressor_decompressed_11;
+    _zz_IBusSimplePlugin_decompressor_decompressed_12[1] = _zz_IBusSimplePlugin_decompressor_decompressed_11;
+    _zz_IBusSimplePlugin_decompressor_decompressed_12[0] = _zz_IBusSimplePlugin_decompressor_decompressed_11;
+  end
+
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_13 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[9] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[8] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[7] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[6] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[5] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[4] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[3] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[2] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[1] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[0] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+  end
+
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_15 = {{{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_14,_zz_IBusSimplePlugin_decompressor_decompressed[8]},_zz_IBusSimplePlugin_decompressor_decompressed[10 : 9]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},_zz_IBusSimplePlugin_decompressor_decompressed[7]},_zz_IBusSimplePlugin_decompressor_decompressed[2]},_zz_IBusSimplePlugin_decompressor_decompressed[11]},_zz_IBusSimplePlugin_decompressor_decompressed[5 : 3]},1'b0};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_16 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[4] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[3] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[2] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[1] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[0] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+  end
+
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_18 = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_17,_zz_IBusSimplePlugin_decompressor_decompressed[6 : 5]},_zz_IBusSimplePlugin_decompressor_decompressed[2]},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10]},_zz_IBusSimplePlugin_decompressor_decompressed[4 : 3]},1'b0};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_19 = 5'h0;
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_20 = 5'h01;
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_21 = 5'h02;
+  assign switch_Misc_l44 = {_zz_IBusSimplePlugin_decompressor_decompressed[1 : 0],_zz_IBusSimplePlugin_decompressor_decompressed[15 : 13]};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_22 = (_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10] != 2'b11);
+  assign switch_Misc_l210 = _zz_IBusSimplePlugin_decompressor_decompressed[11 : 10];
+  assign switch_Misc_l210_1 = _zz_IBusSimplePlugin_decompressor_decompressed[6 : 5];
+  always @(*) begin
+    case(switch_Misc_l210_1)
+      2'b00 : begin
+        _zz_IBusSimplePlugin_decompressor_decompressed_23 = 3'b000;
+      end
+      2'b01 : begin
+        _zz_IBusSimplePlugin_decompressor_decompressed_23 = 3'b100;
+      end
+      2'b10 : begin
+        _zz_IBusSimplePlugin_decompressor_decompressed_23 = 3'b110;
+      end
+      default : begin
+        _zz_IBusSimplePlugin_decompressor_decompressed_23 = 3'b111;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(switch_Misc_l210)
+      2'b00 : begin
+        _zz_IBusSimplePlugin_decompressor_decompressed_24 = 3'b101;
+      end
+      2'b01 : begin
+        _zz_IBusSimplePlugin_decompressor_decompressed_24 = 3'b101;
+      end
+      2'b10 : begin
+        _zz_IBusSimplePlugin_decompressor_decompressed_24 = 3'b111;
+      end
+      default : begin
+        _zz_IBusSimplePlugin_decompressor_decompressed_24 = _zz_IBusSimplePlugin_decompressor_decompressed_23;
+      end
+    endcase
+  end
+
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_25 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[6] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[5] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[4] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[3] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[2] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[1] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[0] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+  end
+
+  assign IBusSimplePlugin_decompressor_output_valid = (IBusSimplePlugin_decompressor_input_valid && (! ((IBusSimplePlugin_decompressor_throw2Bytes && (! IBusSimplePlugin_decompressor_bufferValid)) && (! IBusSimplePlugin_decompressor_isInputHighRvc))));
+  assign IBusSimplePlugin_decompressor_output_payload_pc = IBusSimplePlugin_decompressor_input_payload_pc;
+  assign IBusSimplePlugin_decompressor_output_payload_isRvc = IBusSimplePlugin_decompressor_isRvc;
+  assign IBusSimplePlugin_decompressor_output_payload_rsp_inst = (IBusSimplePlugin_decompressor_isRvc ? IBusSimplePlugin_decompressor_decompressed : IBusSimplePlugin_decompressor_raw);
+  assign IBusSimplePlugin_decompressor_input_ready = (IBusSimplePlugin_decompressor_output_ready && (((! IBusSimplePlugin_iBusRsp_stages_1_input_valid) || IBusSimplePlugin_decompressor_flushNext) || ((! (IBusSimplePlugin_decompressor_bufferValid && IBusSimplePlugin_decompressor_isInputHighRvc)) && (! (((! IBusSimplePlugin_decompressor_unaligned) && IBusSimplePlugin_decompressor_isInputLowRvc) && IBusSimplePlugin_decompressor_isInputHighRvc)))));
+  assign IBusSimplePlugin_decompressor_output_fire = (IBusSimplePlugin_decompressor_output_valid && IBusSimplePlugin_decompressor_output_ready);
+  assign IBusSimplePlugin_decompressor_bufferFill = (((((! IBusSimplePlugin_decompressor_unaligned) && IBusSimplePlugin_decompressor_isInputLowRvc) && (! IBusSimplePlugin_decompressor_isInputHighRvc)) || (IBusSimplePlugin_decompressor_bufferValid && (! IBusSimplePlugin_decompressor_isInputHighRvc))) || ((IBusSimplePlugin_decompressor_throw2Bytes && (! IBusSimplePlugin_decompressor_isRvc)) && (! IBusSimplePlugin_decompressor_isInputHighRvc)));
+  assign when_Fetcher_l286 = (IBusSimplePlugin_decompressor_output_ready && IBusSimplePlugin_decompressor_input_valid);
+  assign when_Fetcher_l289 = (IBusSimplePlugin_decompressor_output_ready && IBusSimplePlugin_decompressor_input_valid);
+  assign when_Fetcher_l294 = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_decompressor_consumeCurrent);
+  assign IBusSimplePlugin_decompressor_output_ready = ((1'b0 && (! IBusSimplePlugin_injector_decodeInput_valid)) || IBusSimplePlugin_injector_decodeInput_ready);
+  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_IBusSimplePlugin_injector_decodeInput_valid;
+  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_IBusSimplePlugin_injector_decodeInput_payload_pc;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  assign when_Fetcher_l332 = (! 1'b0);
+  assign when_Fetcher_l332_1 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_2 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! writeBack_arbitration_isStuck);
+  assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_0;
+  assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
+  assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
+  assign IBusSimplePlugin_pcValids_3 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
+  assign IBusSimplePlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
+  always @(*) begin
+    decode_arbitration_isValid = IBusSimplePlugin_injector_decodeInput_valid;
+    if(IBusSimplePlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
+  assign iBus_cmd_valid = IBusSimplePlugin_cmd_valid;
+  assign IBusSimplePlugin_cmd_ready = iBus_cmd_ready;
+  assign iBus_cmd_payload_pc = IBusSimplePlugin_cmd_payload_pc;
+  assign IBusSimplePlugin_pending_next = (_zz_IBusSimplePlugin_pending_next - _zz_IBusSimplePlugin_pending_next_3);
+  assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != 3'b111));
+  assign when_IBusSimplePlugin_l305 = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready)));
+  assign IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
+  assign IBusSimplePlugin_cmd_fire = (IBusSimplePlugin_cmd_valid && IBusSimplePlugin_cmd_ready);
+  assign IBusSimplePlugin_pending_inc = IBusSimplePlugin_cmd_fire;
+  assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_iBusRsp_stages_0_input_payload[31 : 2],2'b00};
+  assign iBus_rsp_toStream_valid = iBus_rsp_valid;
+  assign iBus_rsp_toStream_payload_error = iBus_rsp_payload_error;
+  assign iBus_rsp_toStream_payload_inst = iBus_rsp_payload_inst;
+  assign iBus_rsp_toStream_ready = IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_flush = ((IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000) || IBusSimplePlugin_iBusRsp_flush);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == 3'b000));
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
+  assign IBusSimplePlugin_pending_dec = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
+  always @(*) begin
+    IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
+    if(when_IBusSimplePlugin_l376) begin
+      IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = 1'b0;
+    end
+  end
+
+  assign IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
+  assign when_IBusSimplePlugin_l376 = (! IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
+  always @(*) begin
+    IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
+    if(when_IBusSimplePlugin_l402) begin
+      IBusSimplePlugin_rspJoin_exceptionDetected = 1'b1;
+    end
+  end
+
+  assign IBusSimplePlugin_rspJoin_join_valid = (IBusSimplePlugin_iBusRsp_stages_1_output_valid && IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
+  assign IBusSimplePlugin_rspJoin_join_payload_pc = IBusSimplePlugin_rspJoin_fetchRsp_pc;
+  assign IBusSimplePlugin_rspJoin_join_payload_rsp_error = IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
+  assign IBusSimplePlugin_rspJoin_join_payload_rsp_inst = IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
+  assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
+  assign IBusSimplePlugin_rspJoin_join_fire = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? IBusSimplePlugin_rspJoin_join_fire : IBusSimplePlugin_rspJoin_join_ready);
+  assign IBusSimplePlugin_rspJoin_join_fire_1 = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = IBusSimplePlugin_rspJoin_join_fire_1;
+  assign _zz_IBusSimplePlugin_iBusRsp_output_valid = (! IBusSimplePlugin_rspJoin_exceptionDetected);
+  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_IBusSimplePlugin_iBusRsp_output_valid);
+  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_IBusSimplePlugin_iBusRsp_output_valid);
+  assign IBusSimplePlugin_iBusRsp_output_payload_pc = IBusSimplePlugin_rspJoin_join_payload_pc;
+  assign IBusSimplePlugin_iBusRsp_output_payload_rsp_error = IBusSimplePlugin_rspJoin_join_payload_rsp_error;
+  assign IBusSimplePlugin_iBusRsp_output_payload_rsp_inst = IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
+  assign IBusSimplePlugin_iBusRsp_output_payload_isRvc = IBusSimplePlugin_rspJoin_join_payload_isRvc;
+  always @(*) begin
+    IBusSimplePlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(when_IBusSimplePlugin_l402) begin
+      IBusSimplePlugin_decodeExceptionPort_payload_code = 4'b0001;
+    end
+  end
+
+  assign IBusSimplePlugin_decodeExceptionPort_payload_badAddr = {IBusSimplePlugin_rspJoin_join_payload_pc[31 : 2],2'b00};
+  assign when_IBusSimplePlugin_l402 = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_payload_rsp_error);
+  assign IBusSimplePlugin_decodeExceptionPort_valid = (IBusSimplePlugin_rspJoin_exceptionDetected && IBusSimplePlugin_iBusRsp_readyForError);
+  assign _zz_dBus_cmd_valid = 1'b0;
+  always @(*) begin
+    execute_DBusSimplePlugin_skipCmd = 1'b0;
+    if(execute_ALIGNEMENT_FAULT) begin
+      execute_DBusSimplePlugin_skipCmd = 1'b1;
+    end
+  end
+
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
+  assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(dBus_cmd_payload_size)
+      2'b00 : begin
+        _zz_dBus_cmd_payload_data = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+      end
+      2'b01 : begin
+        _zz_dBus_cmd_payload_data = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+      end
+      default : begin
+        _zz_dBus_cmd_payload_data = execute_RS2[31 : 0];
+      end
+    endcase
+  end
+
+  assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
+  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  always @(*) begin
+    case(dBus_cmd_payload_size)
+      2'b00 : begin
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0011;
+      end
+      default : begin
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b1111;
+      end
+    endcase
+  end
+
+  assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
+  assign dBus_cmd_payload_address = execute_SRC_ADD;
+  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  always @(*) begin
+    DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
+    if(when_DBusSimplePlugin_l489) begin
+      DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
+    end
+    if(memory_ALIGNEMENT_FAULT) begin
+      DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
+    end
+    if(when_DBusSimplePlugin_l515) begin
+      DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
+    if(when_DBusSimplePlugin_l489) begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
+    end
+    if(memory_ALIGNEMENT_FAULT) begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_DBusSimplePlugin_memoryExceptionPort_payload_code};
+    end
+  end
+
+  assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
+  assign when_DBusSimplePlugin_l489 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l515 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  always @(*) begin
+    writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
+    case(writeBack_MEMORY_ADDRESS_LOW)
+      2'b01 : begin
+        writeBack_DBusSimplePlugin_rspShifted[7 : 0] = writeBack_MEMORY_READ_DATA[15 : 8];
+      end
+      2'b10 : begin
+        writeBack_DBusSimplePlugin_rspShifted[15 : 0] = writeBack_MEMORY_READ_DATA[31 : 16];
+      end
+      2'b11 : begin
+        writeBack_DBusSimplePlugin_rspShifted[7 : 0] = writeBack_MEMORY_READ_DATA[31 : 24];
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign switch_Misc_l210_2 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[30] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[29] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[28] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[27] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[26] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[25] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[24] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[23] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[22] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[21] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[20] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[19] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[18] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[17] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[16] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[15] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[14] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[13] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[12] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[11] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[10] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[9] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[8] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+  end
+
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated_2 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[31] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[30] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[29] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[28] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[27] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[26] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[25] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[24] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[23] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[22] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[21] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[20] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[19] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[18] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[17] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[16] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+  end
+
+  always @(*) begin
+    case(switch_Misc_l210_2)
+      2'b00 : begin
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
+      end
+      2'b01 : begin
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_3;
+      end
+      default : begin
+        writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
+      end
+    endcase
+  end
+
+  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  always @(*) begin
+    CsrPlugin_privilege = 2'b11;
+    if(CsrPlugin_forceMachineWire) begin
+      CsrPlugin_privilege = 2'b11;
+    end
+  end
+
+  assign CsrPlugin_misa_base = 2'b01;
+  assign CsrPlugin_misa_extensions = 26'h0000042;
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusSimplePlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
+    CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
+    end
+    if(decode_arbitration_isFlushed) begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
+    if(CsrPlugin_selfException_valid) begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
+    end
+    if(execute_arbitration_isFlushed) begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+    if(DBusSimplePlugin_memoryExceptionPort_valid) begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
+    end
+    if(memory_arbitration_isFlushed) begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+    if(writeBack_arbitration_isFlushed) begin
+      CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
+    end
+  end
+
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
+  assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
+  assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
+  assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
+  assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
+  assign CsrPlugin_lastStageWasWfi = 1'b0;
+  assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
+    CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
+    if(when_CsrPlugin_l1004) begin
+      CsrPlugin_pipelineLiberator_done = 1'b0;
+    end
+    if(CsrPlugin_hadException) begin
+      CsrPlugin_pipelineLiberator_done = 1'b0;
+    end
+  end
+
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
+  always @(*) begin
+    CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
+    if(CsrPlugin_hadException) begin
+      CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_trapCause = CsrPlugin_interrupt_code;
+    if(CsrPlugin_hadException) begin
+      CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_xtvec_mode = 2'bxx;
+    case(CsrPlugin_targetPrivilege)
+      2'b11 : begin
+        CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    case(CsrPlugin_targetPrivilege)
+      2'b11 : begin
+        CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
+  assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
+  always @(*) begin
+    execute_CsrPlugin_illegalAccess = 1'b1;
+    if(execute_CsrPlugin_csr_768) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_836) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_772) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_773) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
+        execute_CsrPlugin_illegalAccess = 1'b0;
+      end
+    end
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1310) begin
+      execute_CsrPlugin_illegalAccess = 1'b1;
+    end
+    if(when_CsrPlugin_l1315) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    execute_CsrPlugin_illegalInstruction = 1'b0;
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
+        execute_CsrPlugin_illegalInstruction = 1'b1;
+      end
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_selfException_valid = 1'b0;
+    if(when_CsrPlugin_l1167) begin
+      CsrPlugin_selfException_valid = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(when_CsrPlugin_l1167) begin
+      CsrPlugin_selfException_payload_code = 4'b0011;
+    end
+  end
+
+  assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1167 = ((execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_EBREAK)) && CsrPlugin_allowEbreakException);
+  always @(*) begin
+    execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
+    if(when_CsrPlugin_l1310) begin
+      execute_CsrPlugin_writeInstruction = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
+    if(when_CsrPlugin_l1310) begin
+      execute_CsrPlugin_readInstruction = 1'b0;
+    end
+  end
+
+  assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
+  assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l210_3 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l210_3)
+      1'b0 : begin
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+      end
+    endcase
+  end
+
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
+  assign _zz_decode_BRANCH_CTRL_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_BRANCH_CTRL_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_BRANCH_CTRL_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_BRANCH_CTRL_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_BRANCH_CTRL_7 = ((decode_INSTRUCTION & 32'h00000030) == 32'h00000010);
+  assign _zz_decode_BRANCH_CTRL_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_BRANCH_CTRL_2 = {(|{_zz_decode_BRANCH_CTRL_6,(_zz__zz_decode_BRANCH_CTRL_2 == _zz__zz_decode_BRANCH_CTRL_2_1)}),{(|(_zz__zz_decode_BRANCH_CTRL_2_2 == _zz__zz_decode_BRANCH_CTRL_2_3)),{(|{_zz__zz_decode_BRANCH_CTRL_2_4,_zz__zz_decode_BRANCH_CTRL_2_6}),{(|_zz__zz_decode_BRANCH_CTRL_2_8),{_zz__zz_decode_BRANCH_CTRL_2_13,{_zz__zz_decode_BRANCH_CTRL_2_14,_zz__zz_decode_BRANCH_CTRL_2_15}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_BRANCH_CTRL_2[1 : 0];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_BRANCH_CTRL_2[6 : 5];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_BRANCH_CTRL_2[8 : 7];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_BRANCH_CTRL_2[17 : 16];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_BRANCH_CTRL_2[20 : 19];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_BRANCH_CTRL_2[27 : 26];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_9 = _zz_decode_BRANCH_CTRL_2[29 : 28];
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_9;
+  assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
+  assign decodeExceptionPort_payload_code = 4'b0010;
+  assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
+  assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
+  assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_2) begin
+      lastStageRegFileWrite_valid = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_2) begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_lastStageRegFileWrite_payload_data;
+    if(_zz_2) begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
+  always @(*) begin
+    case(execute_ALU_BITWISE_CTRL)
+      AluBitwiseCtrlEnum_AND_1 : begin
+        execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
+      end
+      AluBitwiseCtrlEnum_OR_1 : begin
+        execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
+      end
+      default : begin
+        execute_IntAluPlugin_bitwise = (execute_SRC1 ^ execute_SRC2);
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_ALU_CTRL)
+      AluCtrlEnum_BITWISE : begin
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
+      end
+      AluCtrlEnum_SLT_SLTU : begin
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
+      end
+      default : begin
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      Src1CtrlEnum_RS : begin
+        _zz_decode_SRC1_1 = _zz_decode_SRC1;
+      end
+      Src1CtrlEnum_PC_INCREMENT : begin
+        _zz_decode_SRC1_1 = {29'd0, _zz__zz_decode_SRC1_1};
+      end
+      Src1CtrlEnum_IMU : begin
+        _zz_decode_SRC1_1 = {decode_INSTRUCTION[31 : 12],12'h0};
+      end
+      default : begin
+        _zz_decode_SRC1_1 = {27'd0, _zz__zz_decode_SRC1_1_1};
+      end
+    endcase
+  end
+
+  assign _zz_decode_SRC2_2 = decode_INSTRUCTION[31];
+  always @(*) begin
+    _zz_decode_SRC2_3[19] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[18] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[17] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[16] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[15] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[14] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[13] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[12] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[11] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[10] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[9] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[8] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[7] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[6] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[5] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[4] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[3] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[2] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[1] = _zz_decode_SRC2_2;
+    _zz_decode_SRC2_3[0] = _zz_decode_SRC2_2;
+  end
+
+  assign _zz_decode_SRC2_4 = _zz__zz_decode_SRC2_4[11];
+  always @(*) begin
+    _zz_decode_SRC2_5[19] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[18] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[17] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[16] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[15] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[14] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[13] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[12] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[11] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[10] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[9] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[8] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[7] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[6] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[5] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[4] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[3] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[2] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[1] = _zz_decode_SRC2_4;
+    _zz_decode_SRC2_5[0] = _zz_decode_SRC2_4;
+  end
+
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      Src2CtrlEnum_RS : begin
+        _zz_decode_SRC2_6 = _zz_decode_SRC2_1;
+      end
+      Src2CtrlEnum_IMI : begin
+        _zz_decode_SRC2_6 = {_zz_decode_SRC2_3,decode_INSTRUCTION[31 : 20]};
+      end
+      Src2CtrlEnum_IMS : begin
+        _zz_decode_SRC2_6 = {_zz_decode_SRC2_5,{decode_INSTRUCTION[31 : 25],decode_INSTRUCTION[11 : 7]}};
+      end
+      default : begin
+        _zz_decode_SRC2_6 = _zz_decode_SRC2;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
+      execute_SrcPlugin_addSub = execute_SRC1;
+    end
+  end
+
+  assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
+  assign execute_MulPlugin_a = execute_RS1;
+  assign execute_MulPlugin_b = execute_RS2;
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
+      2'b01 : begin
+        execute_MulPlugin_aSigned = 1'b1;
+      end
+      2'b10 : begin
+        execute_MulPlugin_aSigned = 1'b1;
+      end
+      default : begin
+        execute_MulPlugin_aSigned = 1'b0;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(switch_MulPlugin_l87)
+      2'b01 : begin
+        execute_MulPlugin_bSigned = 1'b1;
+      end
+      2'b10 : begin
+        execute_MulPlugin_bSigned = 1'b0;
+      end
+      default : begin
+        execute_MulPlugin_bSigned = 1'b0;
+      end
+    endcase
+  end
+
+  assign execute_MulPlugin_aULow = execute_MulPlugin_a[15 : 0];
+  assign execute_MulPlugin_bULow = execute_MulPlugin_b[15 : 0];
+  assign execute_MulPlugin_aSLow = {1'b0,execute_MulPlugin_a[15 : 0]};
+  assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
+  assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
+  assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
+  assign memory_DivPlugin_frontendOk = 1'b1;
+  always @(*) begin
+    memory_DivPlugin_div_counter_willIncrement = 1'b0;
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
+        memory_DivPlugin_div_counter_willIncrement = 1'b1;
+      end
+    end
+  end
+
+  always @(*) begin
+    memory_DivPlugin_div_counter_willClear = 1'b0;
+    if(when_MulDivIterativePlugin_l162) begin
+      memory_DivPlugin_div_counter_willClear = 1'b1;
+    end
+  end
+
+  assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
+  assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
+      memory_DivPlugin_div_counter_valueNext = 6'h0;
+    end else begin
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
+    end
+    if(memory_DivPlugin_div_counter_willClear) begin
+      memory_DivPlugin_div_counter_valueNext = 6'h0;
+    end
+  end
+
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
+  end
+
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != ShiftCtrlEnum_DISABLE_1);
+  assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
+  assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
+  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  always @(*) begin
+    case(execute_SHIFT_CTRL)
+      ShiftCtrlEnum_SLL_1 : begin
+        _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (execute_LightShifterPlugin_shiftInput <<< 1);
+      end
+      default : begin
+        _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
+      end
+    endcase
+  end
+
+  assign when_ShiftPlugins_l175 = (! execute_arbitration_isStuckByOthers);
+  assign when_ShiftPlugins_l184 = (! execute_LightShifterPlugin_done);
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        HazardSimplePlugin_src0Hazard = 1'b1;
+      end
+    end
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l59) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l59_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l59_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        HazardSimplePlugin_src1Hazard = 1'b1;
+      end
+    end
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l62) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l62_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l62_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_lastStageRegFileWrite_payload_data;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l59 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b1 || (! 1'b1));
+  assign when_HazardSimplePlugin_l59_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l59_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
+  assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
+  assign switch_Misc_l210_4 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l210_4)
+      3'b000 : begin
+        _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_DO = execute_SRC_LESS;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      BranchCtrlEnum_INC : begin
+        _zz_execute_BRANCH_DO_1 = 1'b0;
+      end
+      BranchCtrlEnum_JAL : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      BranchCtrlEnum_JALR : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      default : begin
+        _zz_execute_BRANCH_DO_1 = _zz_execute_BRANCH_DO;
+      end
+    endcase
+  end
+
+  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JALR) ? execute_RS1 : execute_PC);
+  assign _zz_execute_BranchPlugin_branch_src2 = _zz__zz_execute_BranchPlugin_branch_src2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
+  end
+
+  assign _zz_execute_BranchPlugin_branch_src2_2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[19] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[18] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[17] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[16] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[15] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[14] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[13] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[12] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[11] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
+  end
+
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
+  end
+
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      BranchCtrlEnum_JAL : begin
+        _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_1,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+      end
+      BranchCtrlEnum_JALR : begin
+        _zz_execute_BranchPlugin_branch_src2_6 = {_zz_execute_BranchPlugin_branch_src2_3,execute_INSTRUCTION[31 : 20]};
+      end
+      default : begin
+        _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+      end
+    endcase
+  end
+
+  assign execute_BranchPlugin_branch_src2 = _zz_execute_BranchPlugin_branch_src2_6;
+  assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
+  assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
+  assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_17 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_26 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_27 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
+  assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_48 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
+  assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
+  assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
+  assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign decode_arbitration_isFiring = ((decode_arbitration_isValid && (! decode_arbitration_isStuck)) && (! decode_arbitration_removeIt));
+  assign execute_arbitration_isStuckByOthers = (execute_arbitration_haltByOther || ((1'b0 || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
+  assign execute_arbitration_isStuck = (execute_arbitration_haltItself || execute_arbitration_isStuckByOthers);
+  assign execute_arbitration_isMoving = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign execute_arbitration_isFiring = ((execute_arbitration_isValid && (! execute_arbitration_isStuck)) && (! execute_arbitration_removeIt));
+  assign memory_arbitration_isStuckByOthers = (memory_arbitration_haltByOther || (1'b0 || writeBack_arbitration_isStuck));
+  assign memory_arbitration_isStuck = (memory_arbitration_haltItself || memory_arbitration_isStuckByOthers);
+  assign memory_arbitration_isMoving = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign memory_arbitration_isFiring = ((memory_arbitration_isValid && (! memory_arbitration_isStuck)) && (! memory_arbitration_removeIt));
+  assign writeBack_arbitration_isStuckByOthers = (writeBack_arbitration_haltByOther || 1'b0);
+  assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
+  assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
+  assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit[12 : 11] = CsrPlugin_mstatus_MPP;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_1[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[3 : 3] = CsrPlugin_mip_MSIP;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mie_MSIE;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[1 : 0] = CsrPlugin_mtvec_mode;
+    end
+  end
+
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 0] = CsrPlugin_mcause_exceptionCode;
+    end
+  end
+
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit | _zz_CsrPlugin_csrMapping_readDataInit_1) | (_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3)) | _zz_CsrPlugin_csrMapping_readDataInit_4);
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  always @(*) begin
+    iBus_cmd_ready = iBus_cmd_m2sPipe_ready;
+    if(when_Stream_l368) begin
+      iBus_cmd_ready = 1'b1;
+    end
+  end
+
+  assign when_Stream_l368 = (! iBus_cmd_m2sPipe_valid);
+  assign iBus_cmd_m2sPipe_valid = iBus_cmd_rValid;
+  assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_rData_pc;
+  assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
+  assign iBusWishbone_CTI = 3'b000;
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
+  assign iBusWishbone_WE = 1'b0;
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  assign iBusWishbone_CYC = iBus_cmd_m2sPipe_valid;
+  assign iBusWishbone_STB = iBus_cmd_m2sPipe_valid;
+  assign iBus_cmd_m2sPipe_ready = (iBus_cmd_m2sPipe_valid && iBusWishbone_ACK);
+  assign iBus_rsp_valid = (iBusWishbone_CYC && iBusWishbone_ACK);
+  assign iBus_rsp_payload_inst = iBusWishbone_DAT_MISO;
+  assign iBus_rsp_payload_error = 1'b0;
+  assign dBus_cmd_halfPipe_fire = (dBus_cmd_halfPipe_valid && dBus_cmd_halfPipe_ready);
+  assign dBus_cmd_ready = (! dBus_cmd_rValid);
+  assign dBus_cmd_halfPipe_valid = dBus_cmd_rValid;
+  assign dBus_cmd_halfPipe_payload_wr = dBus_cmd_rData_wr;
+  assign dBus_cmd_halfPipe_payload_address = dBus_cmd_rData_address;
+  assign dBus_cmd_halfPipe_payload_data = dBus_cmd_rData_data;
+  assign dBus_cmd_halfPipe_payload_size = dBus_cmd_rData_size;
+  assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
+  assign dBusWishbone_CTI = 3'b000;
+  assign dBusWishbone_BTE = 2'b00;
+  always @(*) begin
+    case(dBus_cmd_halfPipe_payload_size)
+      2'b00 : begin
+        _zz_dBusWishbone_SEL = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_dBusWishbone_SEL = 4'b0011;
+      end
+      default : begin
+        _zz_dBusWishbone_SEL = 4'b1111;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    if(when_DBusSimplePlugin_l189) begin
+      dBusWishbone_SEL = 4'b1111;
+    end
+  end
+
+  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
+  assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
+  assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
+  assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = dBus_cmd_halfPipe_valid;
+  assign dBusWishbone_STB = dBus_cmd_halfPipe_valid;
+  assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+  assign dBus_rsp_data = dBusWishbone_DAT_MISO;
+  assign dBus_rsp_error = 1'b0;
+  always @(posedge clk or posedge reset) begin
+    if(reset) begin
+      IBusSimplePlugin_fetchPc_pcReg <= 32'h20000000;
+      IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
+      IBusSimplePlugin_fetchPc_booted <= 1'b0;
+      IBusSimplePlugin_fetchPc_inc <= 1'b0;
+      IBusSimplePlugin_decodePc_pcReg <= 32'h20000000;
+      _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      IBusSimplePlugin_decompressor_bufferValid <= 1'b0;
+      IBusSimplePlugin_decompressor_throw2BytesReg <= 1'b0;
+      _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
+      IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
+      IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
+      IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
+      IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      IBusSimplePlugin_pending_value <= 3'b000;
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
+      CsrPlugin_mtvec_mode <= 2'b00;
+      CsrPlugin_mtvec_base <= 30'h00000008;
+      CsrPlugin_mstatus_MIE <= 1'b0;
+      CsrPlugin_mstatus_MPIE <= 1'b0;
+      CsrPlugin_mstatus_MPP <= 2'b11;
+      CsrPlugin_mie_MEIE <= 1'b0;
+      CsrPlugin_mie_MTIE <= 1'b0;
+      CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
+      CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
+      CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
+      CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
+      CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
+      CsrPlugin_interrupt_valid <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
+      CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
+      CsrPlugin_hadException <= 1'b0;
+      execute_CsrPlugin_wfiWake <= 1'b0;
+      _zz_2 <= 1'b1;
+      memory_DivPlugin_div_counter_value <= 6'h0;
+      execute_LightShifterPlugin_isActive <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
+      execute_arbitration_isValid <= 1'b0;
+      memory_arbitration_isValid <= 1'b0;
+      writeBack_arbitration_isValid <= 1'b0;
+      iBus_cmd_rValid <= 1'b0;
+      dBus_cmd_rValid <= 1'b0;
+    end else begin
+      if(IBusSimplePlugin_fetchPc_correction) begin
+        IBusSimplePlugin_fetchPc_correctionReg <= 1'b1;
+      end
+      if(IBusSimplePlugin_fetchPc_output_fire) begin
+        IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
+      end
+      IBusSimplePlugin_fetchPc_booted <= 1'b1;
+      if(when_Fetcher_l134) begin
+        IBusSimplePlugin_fetchPc_inc <= 1'b0;
+      end
+      if(IBusSimplePlugin_fetchPc_output_fire_1) begin
+        IBusSimplePlugin_fetchPc_inc <= 1'b1;
+      end
+      if(when_Fetcher_l134_1) begin
+        IBusSimplePlugin_fetchPc_inc <= 1'b0;
+      end
+      if(when_Fetcher_l161) begin
+        IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
+      end
+      if(when_Fetcher_l183) begin
+        IBusSimplePlugin_decodePc_pcReg <= IBusSimplePlugin_decodePc_pcPlus;
+      end
+      if(when_Fetcher_l195) begin
+        IBusSimplePlugin_decodePc_pcReg <= IBusSimplePlugin_jump_pcLoad_payload;
+      end
+      if(IBusSimplePlugin_iBusRsp_flush) begin
+        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      end
+      if(_zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      end
+      if(IBusSimplePlugin_decompressor_output_fire) begin
+        IBusSimplePlugin_decompressor_throw2BytesReg <= ((((! IBusSimplePlugin_decompressor_unaligned) && IBusSimplePlugin_decompressor_isInputLowRvc) && IBusSimplePlugin_decompressor_isInputHighRvc) || (IBusSimplePlugin_decompressor_bufferValid && IBusSimplePlugin_decompressor_isInputHighRvc));
+      end
+      if(when_Fetcher_l286) begin
+        IBusSimplePlugin_decompressor_bufferValid <= 1'b0;
+      end
+      if(when_Fetcher_l289) begin
+        if(IBusSimplePlugin_decompressor_bufferFill) begin
+          IBusSimplePlugin_decompressor_bufferValid <= 1'b1;
+        end
+      end
+      if(when_Fetcher_l294) begin
+        IBusSimplePlugin_decompressor_throw2BytesReg <= 1'b0;
+        IBusSimplePlugin_decompressor_bufferValid <= 1'b0;
+      end
+      if(decode_arbitration_removeIt) begin
+        _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
+      end
+      if(IBusSimplePlugin_decompressor_output_ready) begin
+        _zz_IBusSimplePlugin_injector_decodeInput_valid <= (IBusSimplePlugin_decompressor_output_valid && (! IBusSimplePlugin_externalFlush));
+      end
+      if(when_Fetcher_l332) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b1;
+      end
+      if(IBusSimplePlugin_decodePc_flushed) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
+      end
+      if(when_Fetcher_l332_1) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_1 <= IBusSimplePlugin_injector_nextPcCalc_valids_0;
+      end
+      if(IBusSimplePlugin_decodePc_flushed) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
+      end
+      if(when_Fetcher_l332_2) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_2 <= IBusSimplePlugin_injector_nextPcCalc_valids_1;
+      end
+      if(IBusSimplePlugin_decodePc_flushed) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
+      end
+      if(when_Fetcher_l332_3) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_3 <= IBusSimplePlugin_injector_nextPcCalc_valids_2;
+      end
+      if(IBusSimplePlugin_decodePc_flushed) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      end
+      IBusSimplePlugin_pending_value <= IBusSimplePlugin_pending_next;
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter);
+      if(IBusSimplePlugin_iBusRsp_flush) begin
+        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2);
+      end
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
+      end else begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
+      end
+      if(when_CsrPlugin_l922_1) begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
+      end else begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
+      end
+      if(when_CsrPlugin_l922_2) begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
+      end else begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
+      end
+      if(when_CsrPlugin_l922_3) begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
+      end else begin
+        CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
+      end
+      CsrPlugin_interrupt_valid <= 1'b0;
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
+          CsrPlugin_interrupt_valid <= 1'b1;
+        end
+        if(when_CsrPlugin_l965_1) begin
+          CsrPlugin_interrupt_valid <= 1'b1;
+        end
+        if(when_CsrPlugin_l965_2) begin
+          CsrPlugin_interrupt_valid <= 1'b1;
+        end
+      end
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l993) begin
+          CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
+        end
+        if(when_CsrPlugin_l993_1) begin
+          CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
+        end
+        if(when_CsrPlugin_l993_2) begin
+          CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
+        end
+      end
+      if(when_CsrPlugin_l998) begin
+        CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
+        CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
+        CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
+      end
+      if(CsrPlugin_interruptJump) begin
+        CsrPlugin_interrupt_valid <= 1'b0;
+      end
+      CsrPlugin_hadException <= CsrPlugin_exception;
+      if(when_CsrPlugin_l1032) begin
+        case(CsrPlugin_targetPrivilege)
+          2'b11 : begin
+            CsrPlugin_mstatus_MIE <= 1'b0;
+            CsrPlugin_mstatus_MPIE <= CsrPlugin_mstatus_MIE;
+            CsrPlugin_mstatus_MPP <= CsrPlugin_privilege;
+          end
+          default : begin
+          end
+        endcase
+      end
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
+          2'b11 : begin
+            CsrPlugin_mstatus_MPP <= 2'b00;
+            CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
+            CsrPlugin_mstatus_MPIE <= 1'b1;
+          end
+          default : begin
+          end
+        endcase
+      end
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      _zz_2 <= 1'b0;
+      memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
+      if(when_ShiftPlugins_l169) begin
+        if(when_ShiftPlugins_l175) begin
+          execute_LightShifterPlugin_isActive <= 1'b1;
+          if(execute_LightShifterPlugin_done) begin
+            execute_LightShifterPlugin_isActive <= 1'b0;
+          end
+        end
+      end
+      if(execute_arbitration_removeIt) begin
+        execute_LightShifterPlugin_isActive <= 1'b0;
+      end
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_Pipeline_l151) begin
+        execute_arbitration_isValid <= 1'b0;
+      end
+      if(when_Pipeline_l154) begin
+        execute_arbitration_isValid <= decode_arbitration_isValid;
+      end
+      if(when_Pipeline_l151_1) begin
+        memory_arbitration_isValid <= 1'b0;
+      end
+      if(when_Pipeline_l154_1) begin
+        memory_arbitration_isValid <= execute_arbitration_isValid;
+      end
+      if(when_Pipeline_l151_2) begin
+        writeBack_arbitration_isValid <= 1'b0;
+      end
+      if(when_Pipeline_l154_2) begin
+        writeBack_arbitration_isValid <= memory_arbitration_isValid;
+      end
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
+        end
+      end
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_773) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+          CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
+        end
+      end
+      if(iBus_cmd_ready) begin
+        iBus_cmd_rValid <= iBus_cmd_valid;
+      end
+      if(dBus_cmd_valid) begin
+        dBus_cmd_rValid <= 1'b1;
+      end
+      if(dBus_cmd_halfPipe_fire) begin
+        dBus_cmd_rValid <= 1'b0;
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if(IBusSimplePlugin_decompressor_input_valid) begin
+      IBusSimplePlugin_decompressor_bufferValidLatch <= IBusSimplePlugin_decompressor_bufferValid;
+    end
+    if(IBusSimplePlugin_decompressor_input_valid) begin
+      IBusSimplePlugin_decompressor_throw2BytesLatch <= IBusSimplePlugin_decompressor_throw2Bytes;
+    end
+    if(when_Fetcher_l289) begin
+      IBusSimplePlugin_decompressor_bufferData <= IBusSimplePlugin_decompressor_input_payload_rsp_inst[31 : 16];
+    end
+    if(IBusSimplePlugin_decompressor_output_ready) begin
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_pc <= IBusSimplePlugin_decompressor_output_payload_pc;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error <= IBusSimplePlugin_decompressor_output_payload_rsp_error;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= IBusSimplePlugin_decompressor_output_payload_rsp_inst;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc <= IBusSimplePlugin_decompressor_output_payload_isRvc;
+    end
+    if(IBusSimplePlugin_injector_decodeInput_ready) begin
+      IBusSimplePlugin_injector_formal_rawInDecode <= IBusSimplePlugin_decompressor_raw;
+    end
+    CsrPlugin_mip_MEIP <= externalInterrupt;
+    CsrPlugin_mip_MTIP <= timerInterrupt;
+    CsrPlugin_mip_MSIP <= softwareInterrupt;
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusSimplePlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusSimplePlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    end
+    if(CsrPlugin_selfException_valid) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
+    end
+    if(DBusSimplePlugin_memoryExceptionPort_valid) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusSimplePlugin_memoryExceptionPort_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
+    end
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(when_CsrPlugin_l965_1) begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(when_CsrPlugin_l965_2) begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+    end
+    if(when_CsrPlugin_l1032) begin
+      case(CsrPlugin_targetPrivilege)
+        2'b11 : begin
+          CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
+          CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
+          CsrPlugin_mepc <= writeBack_PC;
+          if(CsrPlugin_hadException) begin
+            CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
+          end
+        end
+        default : begin
+        end
+      endcase
+    end
+    if(when_MulDivIterativePlugin_l126) begin
+      memory_DivPlugin_div_done <= 1'b1;
+    end
+    if(when_MulDivIterativePlugin_l126_1) begin
+      memory_DivPlugin_div_done <= 1'b0;
+    end
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
+        memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
+        memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
+        end
+      end
+    end
+    if(when_MulDivIterativePlugin_l162) begin
+      memory_DivPlugin_accumulator <= 65'h0;
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+    end
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l175) begin
+        execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
+      end
+    end
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
+    if(when_Pipeline_l124) begin
+      decode_to_execute_PC <= _zz_decode_SRC2;
+    end
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= execute_PC;
+    end
+    if(when_Pipeline_l124_2) begin
+      memory_to_writeBack_PC <= memory_PC;
+    end
+    if(when_Pipeline_l124_3) begin
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+    end
+    if(when_Pipeline_l124_4) begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if(when_Pipeline_l124_5) begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
+    end
+    if(when_Pipeline_l124_7) begin
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+    end
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+    end
+    if(when_Pipeline_l124_9) begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if(when_Pipeline_l124_11) begin
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+    end
+    if(when_Pipeline_l124_12) begin
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
+    end
+    if(when_Pipeline_l124_13) begin
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+    end
+    if(when_Pipeline_l124_14) begin
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+    end
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
+    end
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
+    if(when_Pipeline_l124_17) begin
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if(when_Pipeline_l124_18) begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if(when_Pipeline_l124_19) begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if(when_Pipeline_l124_20) begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+    end
+    if(when_Pipeline_l124_21) begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+    end
+    if(when_Pipeline_l124_22) begin
+      decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
+    end
+    if(when_Pipeline_l124_23) begin
+      execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
+    end
+    if(when_Pipeline_l124_24) begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if(when_Pipeline_l124_25) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+    end
+    if(when_Pipeline_l124_26) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+    end
+    if(when_Pipeline_l124_27) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+    end
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+    end
+    if(when_Pipeline_l124_30) begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if(when_Pipeline_l124_31) begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if(when_Pipeline_l124_32) begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+    end
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if(when_Pipeline_l124_35) begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if(when_Pipeline_l124_36) begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if(when_Pipeline_l124_37) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+    end
+    if(when_Pipeline_l124_38) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+    end
+    if(when_Pipeline_l124_39) begin
+      decode_to_execute_RS1 <= _zz_decode_SRC1;
+    end
+    if(when_Pipeline_l124_40) begin
+      decode_to_execute_RS2 <= _zz_decode_SRC2_1;
+    end
+    if(when_Pipeline_l124_41) begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if(when_Pipeline_l124_42) begin
+      decode_to_execute_SRC1 <= decode_SRC1;
+    end
+    if(when_Pipeline_l124_43) begin
+      decode_to_execute_SRC2 <= decode_SRC2;
+    end
+    if(when_Pipeline_l124_44) begin
+      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
+    end
+    if(when_Pipeline_l124_45) begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if(when_Pipeline_l124_46) begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if(when_Pipeline_l124_47) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_execute_to_memory_REGFILE_WRITE_DATA;
+    end
+    if(when_Pipeline_l124_48) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_memory_to_writeBack_REGFILE_WRITE_DATA;
+    end
+    if(when_Pipeline_l124_49) begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if(when_Pipeline_l124_50) begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_51) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if(when_Pipeline_l124_52) begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if(when_Pipeline_l124_53) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_54) begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if(when_Pipeline_l124_55) begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if(when_Pipeline_l124_56) begin
+      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
+    end
+    if(when_Pipeline_l124_57) begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+    end
+    if(when_CsrPlugin_l1277) begin
+      execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
+    end
+    if(when_CsrPlugin_l1277_1) begin
+      execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
+    end
+    if(when_CsrPlugin_l1277_2) begin
+      execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
+    end
+    if(when_CsrPlugin_l1277_3) begin
+      execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
+    end
+    if(when_CsrPlugin_l1277_4) begin
+      execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
+    end
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
+      end
+    end
+    if(iBus_cmd_ready) begin
+      iBus_cmd_rData_pc <= iBus_cmd_payload_pc;
+    end
+    if(dBus_cmd_ready) begin
+      dBus_cmd_rData_wr <= dBus_cmd_payload_wr;
+      dBus_cmd_rData_address <= dBus_cmd_payload_address;
+      dBus_cmd_rData_data <= dBus_cmd_payload_data;
+      dBus_cmd_rData_size <= dBus_cmd_payload_size;
+    end
+  end
+
+
+endmodule
+
+module StreamFifoLowLatency (
+  input               io_push_valid,
+  output              io_push_ready,
+  input               io_push_payload_error,
+  input      [31:0]   io_push_payload_inst,
+  output reg          io_pop_valid,
+  input               io_pop_ready,
+  output reg          io_pop_payload_error,
+  output reg [31:0]   io_pop_payload_inst,
+  input               io_flush,
+  output     [0:0]    io_occupancy,
+  input               clk,
+  input               reset
+);
+
+  reg                 when_Phase_l649;
+  reg                 pushPtr_willIncrement;
+  reg                 pushPtr_willClear;
+  wire                pushPtr_willOverflowIfInc;
+  wire                pushPtr_willOverflow;
+  reg                 popPtr_willIncrement;
+  reg                 popPtr_willClear;
+  wire                popPtr_willOverflowIfInc;
+  wire                popPtr_willOverflow;
+  wire                ptrMatch;
+  reg                 risingOccupancy;
+  wire                empty;
+  wire                full;
+  wire                pushing;
+  wire                popping;
+  wire                readed_error;
+  wire       [31:0]   readed_inst;
+  wire       [32:0]   _zz_readed_error;
+  wire                when_Stream_l1178;
+  wire                when_Stream_l1191;
+  wire       [32:0]   _zz_readed_error_1;
+  reg        [32:0]   _zz_readed_error_2;
+
+  always @(*) begin
+    when_Phase_l649 = 1'b0;
+    if(pushing) begin
+      when_Phase_l649 = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    pushPtr_willIncrement = 1'b0;
+    if(pushing) begin
+      pushPtr_willIncrement = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    pushPtr_willClear = 1'b0;
+    if(io_flush) begin
+      pushPtr_willClear = 1'b1;
+    end
+  end
+
+  assign pushPtr_willOverflowIfInc = 1'b1;
+  assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
+  always @(*) begin
+    popPtr_willIncrement = 1'b0;
+    if(popping) begin
+      popPtr_willIncrement = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    popPtr_willClear = 1'b0;
+    if(io_flush) begin
+      popPtr_willClear = 1'b1;
+    end
+  end
+
+  assign popPtr_willOverflowIfInc = 1'b1;
+  assign popPtr_willOverflow = (popPtr_willOverflowIfInc && popPtr_willIncrement);
+  assign ptrMatch = 1'b1;
+  assign empty = (ptrMatch && (! risingOccupancy));
+  assign full = (ptrMatch && risingOccupancy);
+  assign pushing = (io_push_valid && io_push_ready);
+  assign popping = (io_pop_valid && io_pop_ready);
+  assign io_push_ready = (! full);
+  assign _zz_readed_error = _zz_readed_error_1;
+  assign readed_error = _zz_readed_error[0];
+  assign readed_inst = _zz_readed_error[32 : 1];
+  assign when_Stream_l1178 = (! empty);
+  always @(*) begin
+    if(when_Stream_l1178) begin
+      io_pop_valid = 1'b1;
+    end else begin
+      io_pop_valid = io_push_valid;
+    end
+  end
+
+  always @(*) begin
+    if(when_Stream_l1178) begin
+      io_pop_payload_error = readed_error;
+    end else begin
+      io_pop_payload_error = io_push_payload_error;
+    end
+  end
+
+  always @(*) begin
+    if(when_Stream_l1178) begin
+      io_pop_payload_inst = readed_inst;
+    end else begin
+      io_pop_payload_inst = io_push_payload_inst;
+    end
+  end
+
+  assign when_Stream_l1191 = (pushing != popping);
+  assign io_occupancy = (risingOccupancy && ptrMatch);
+  assign _zz_readed_error_1 = _zz_readed_error_2;
+  always @(posedge clk or posedge reset) begin
+    if(reset) begin
+      risingOccupancy <= 1'b0;
+    end else begin
+      if(when_Stream_l1191) begin
+        risingOccupancy <= pushing;
+      end
+      if(io_flush) begin
+        risingOccupancy <= 1'b0;
+      end
+    end
+  end
+
+  always @(posedge clk) begin
+    if(when_Phase_l649) begin
+      _zz_readed_error_2 <= {io_push_payload_inst,io_push_payload_error};
+    end
+  end
+
+
+endmodule

--- a/clash-vexriscv/example-cpu/VexRiscv.v.license
+++ b/clash-vexriscv/example-cpu/VexRiscv.v.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Google LLC
+
+SPDX-License-Identifier: Apache-2.0

--- a/clash-vexriscv/src/VexRiscv.hs
+++ b/clash-vexriscv/src/VexRiscv.hs
@@ -21,9 +21,10 @@ import GHC.IO (unsafePerformIO)
 import GHC.Stack (HasCallStack)
 import Protocols.Wishbone
 import VexRiscv.FFI
+import VexRiscv.TH
 import qualified Data.List
 import Language.Haskell.TH.Syntax
-import Paths_clash_vexriscv
+
 
 data Input = Input
   { timerInterrupt :: Bit
@@ -296,8 +297,8 @@ vexRiscv# !_clk rst0
         in unlines l1
 
       vexRiscvSrc0 = $(do
-        elfPath <- runIO $ getDataFileName "build_out_dir/VexRiscv.v"
-        content <- runIO $ readFile elfPath
+        cpuSrcPath <- runIO $ getPackageRelFilePath "example-cpu/VexRiscv.v"
+        content <- runIO $ readFile cpuSrcPath
         pure $ LitE $ StringL content
         )
       vexRiscvSrc1 = indent 6 vexRiscvSrc0

--- a/clash-vexriscv/src/VexRiscv/TH.hs
+++ b/clash-vexriscv/src/VexRiscv/TH.hs
@@ -1,0 +1,74 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE MultiWayIf #-}
+
+module VexRiscv.TH where
+
+import Prelude
+
+import Data.Char
+
+import System.FilePath
+import System.FilePath.Glob
+import System.Directory
+
+import Language.Haskell.TH
+
+import GHC.Stack
+
+packageName :: String
+packageName =
+  let
+    locName = $(do
+      loc <- location
+      pure $ LitE $ StringL $ loc_package loc
+      )
+    
+    dropLast []     = []
+    dropLast [_]    = []
+    dropLast (x:xs) = x : dropLast xs
+  in dropLast $ takeWhile (not . isNumber) locName
+
+getPackageRelFilePath :: FilePath -> IO FilePath
+getPackageRelFilePath path = do
+  putStrLn $ "package name: " <> packageName
+  packageManifestPath <- findCabalPackage packageName
+  putStrLn $ "Package manifest path: " <> packageManifestPath
+  let packagePath = takeDirectory packageManifestPath
+  pure $ packagePath </> path
+
+-- | Searches for a file called @package.cabal@, where @package@ is given as an
+-- argument. It will look for it in the current directory. If it can't find it
+-- there, it will traverse up until it finds the file or a file called
+-- @cabal.project@. In case of the latter, it will traverse down recursively
+-- until it encounters a @package.cabal@.
+--
+-- The returned path points to the @package.cabal@. Errors if it could not
+-- find @package.cabal@ anywhere, or when it found multiple.
+--
+findCabalPackage :: HasCallStack => String -> IO FilePath
+findCabalPackage pkgName = goUp =<< canonicalizePath pkgName
+ where
+  goUp :: FilePath -> IO FilePath
+  goUp path
+    | isDrive path = error ("Could not find '" <> packageFilename <> "'")
+    | otherwise = do
+      packageExists <- doesFileExist (path </> packageFilename)
+      projectExists <- doesFileExist (path </> projectFilename)
+
+      if | packageExists -> pure (path </> packageFilename)
+         | projectExists -> goDown path
+         | otherwise -> goUp (takeDirectory path)
+
+  goDown :: FilePath -> IO FilePath
+  goDown path = do
+    candidates <- glob (path </> "**" </> packageFilename)
+    case candidates of
+      [] -> error ("Could not find " <> packageFilename <> " in project " <> path)
+      (_:_:_) -> error ("Ambiguous packages in project " <> path <> ": " <> show candidates)
+      [c] -> pure c
+
+  packageFilename = pkgName <> ".cabal"
+  projectFilename = "cabal.project"


### PR DESCRIPTION
After this is merged, a check on CI should be added to make sure the committed `example-cpu/VexRiscv.v` is the same as the generated one.