### PR TITLE
Add GHC 9.2 and 9.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Google LLC
-# 
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: CI
@@ -54,7 +54,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --target riscv32imc-unknown-none-elf --all-features
-  
+
   rust-build-programs:
     name: Build Programs
     runs-on: ubuntu-22.04
@@ -69,6 +69,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y curl build-essential
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.67.1 # See Note [Updating Rust versions]
@@ -76,21 +77,24 @@ jobs:
           target: riscv32imc-unknown-none-elf
           components: clippy, rustfmt
 
+      - name: Caching
+        uses: Swatinem/rust-cache@v2
+
       - name: Build release binaries
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release
-      
+
       - name: Build debug binaries
         uses: actions-rs/cargo@v1
         with:
           command: build
-      
+
       - name: Archive Integration Test Binaries
         run: |
           cd clash-vexriscv-sim; sh bundle_test_binaries.sh
-      
+
       - name: Upload Integration Test Binaries
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
       matrix:
         ghc:
           - "9.0.2"
+          - "9.2.8"
+          - "9.4.8"
 
     container:
       image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20240221

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,14 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [rust-build-programs]
 
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc:
+          - "9.0.2"
+
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
+      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20240221
 
     steps:
       - name: Checkout
@@ -124,8 +130,8 @@ jobs:
         with:
           path: |
             ~/.cabal/store
-          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-1-
+          key: packages-cachebust-2-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
+          restore-keys: packages-cachebust-2-${{ matrix.ghc }}
 
       - name: Install build deps
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -8,8 +8,6 @@ packages:
 
 write-ghc-environment-files: always
 
-with-compiler: ghc-9.0.2
-
 tests: True
 
 
@@ -49,9 +47,9 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: f7ea04834d396669fe4ef404b03541601a68b136
+  tag: eb76cd1be746ae91beff60c0f16d8c1dd888662c
 
 source-repository-package
   type: git
   location: https://github.com/cchalmers/circuit-notation.git
-  tag: 618e37578e699df235f2e7150108b6401731919b
+  tag: 19b386c4aa3ff690758ae089c7754303f3500cc9

--- a/clash-vexriscv-sim/clash-vexriscv-sim.cabal
+++ b/clash-vexriscv-sim/clash-vexriscv-sim.cabal
@@ -60,9 +60,9 @@ common common-options
     -fno-worker-wrapper
       -- clash-prelude will set suitable version bounds for the plugins
   build-depends:
-    base >= 4.14 && < 4.16,
+    base >= 4.14 && < 4.19,
     clash-prelude >= 1.6 && < 1.10,
-    containers >= 0.6 && < 0.7,
+    containers >= 0.6 && < 0.8,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
@@ -79,11 +79,11 @@ library
     Utils.Storage
   build-depends:
     base,
+    bytestring >= 0.10 && < 0.13,
     clash-prelude,
     clash-protocols,
     clash-vexriscv,
     elf >= 0.31 && < 0.32,
-    bytestring >= 0.10 && < 0.11,
 
 executable clash
   import: common-options
@@ -132,6 +132,6 @@ test-suite unittests
     containers,
     directory,
     temporary >=1.1 && <1.4,
-    tasty >= 1.2 && < 1.5,
+    tasty >= 1.2 && < 1.6,
     tasty-hunit >= 0.10 && < 0.11,
     filepath

--- a/clash-vexriscv-sim/src/Utils/Cpu.hs
+++ b/clash-vexriscv-sim/src/Utils/Cpu.hs
@@ -11,6 +11,7 @@ import Clash.Prelude
 
 import Protocols.Wishbone
 import VexRiscv
+import VexRiscv.VecToTuple (vecToTuple)
 
 import GHC.Stack (HasCallStack)
 
@@ -61,7 +62,7 @@ cpu bootIMem bootDMem = (output, writes, iS2M, dS2M)
     dummyS2M = dummy dummyM2S
     bootDS2M = bootDMem bootDM2S
 
-    (dS2M, unbundle -> (dummyM2S :> bootDM2S :> Nil)) = interconnectTwo
+    (dS2M, vecToTuple . unbundle -> (dummyM2S, bootDM2S)) = interconnectTwo
       (unBusAddr <$> dM2S)
       ((0x0000_0000, dummyS2M) :> (0x4000_0000, bootDS2M) :> Nil)
 

--- a/clash-vexriscv-sim/src/Utils/ProgramLoad.hs
+++ b/clash-vexriscv-sim/src/Utils/ProgramLoad.hs
@@ -33,8 +33,8 @@ loadProgram path = do
 
   let
       endianSwap dat =
-        L.concatMap (\[a, b, c, d] -> [d, c, b, a]) $
-        chunkFill 4 0 dat
+        L.concatMap (\(a, b, c, d) -> [d, c, b, a]) $
+        chunkFill4 0 dat
 
       -- endian swap instructions
       iMemContents = endianSwap $
@@ -51,9 +51,10 @@ loadProgram path = do
     content :: BinaryData -> [BitVector 8]
     content bin = L.map snd $ I.toAscList bin
 
-    chunkFill :: Int -> a -> [a] -> [[a]]
-    chunkFill _ _ [] = []
-    chunkFill n fill xs =
-      let (first0, rest) = L.splitAt n xs
-          first1 = first0 <> L.replicate (n - L.length first0) fill
-       in first1 : chunkFill n fill rest
+    chunkFill4 :: a -> [a] -> [(a, a, a, a)]
+    chunkFill4 fill = \case
+      [] -> []
+      [a] -> [(a, fill, fill, fill)]
+      [a, b] -> [(a, b, fill, fill)]
+      [a, b, c] -> [(a, b, c, fill)]
+      (a:b:c:d:rest) -> (a, b, c, d) : chunkFill4 fill rest

--- a/clash-vexriscv/Makefile
+++ b/clash-vexriscv/Makefile
@@ -40,13 +40,17 @@ $(OUT_DIR)/impl.o: $(FFI_DIR)/impl.cpp $(FFI_DIR)/interface.h
 $(OUT_DIR)/verilated.o: $(shell pkg-config --variable=includedir verilator)/verilated.cpp
 	$(CXX) $(FFI_CPPFLAGS) -c $(shell pkg-config --variable=includedir verilator)/verilated.cpp -o $(OUT_DIR)/verilated.o
 
+$(OUT_DIR)/verilated_threads.o: $(shell pkg-config --variable=includedir verilator)/verilated_threads.cpp
+	$(CXX) $(FFI_CPPFLAGS) -c $(shell pkg-config --variable=includedir verilator)/verilated_threads.cpp -o $(OUT_DIR)/verilated_threads.o
+
 $(OUT_DIR)/VVexRiscv__ALL.a: $(VERILATOR_DIR)/VVexRiscv__ALL.a
 	cp $(VERILATOR_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/VVexRiscv__ALL.a
 
-$(OUT_DIR)/libVexRiscvFFI.a: $(OUT_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/impl.o $(OUT_DIR)/verilated.o
+$(OUT_DIR)/libVexRiscvFFI.a: $(OUT_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/impl.o $(OUT_DIR)/verilated.o $(OUT_DIR)/verilated_threads.o
 	rm -f $(OUT_DIR)/libVexRiscvFFI.a
 	cp $(OUT_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/libVexRiscvFFI.a
 	ar r \
 		$(OUT_DIR)/libVexRiscvFFI.a \
 		$(OUT_DIR)/impl.o \
-		$(OUT_DIR)/verilated.o
+		$(OUT_DIR)/verilated.o \
+		$(OUT_DIR)/verilated_threads.o

--- a/clash-vexriscv/clash-vexriscv.cabal
+++ b/clash-vexriscv/clash-vexriscv.cabal
@@ -87,9 +87,9 @@ common common-options
     -fno-worker-wrapper
       -- clash-prelude will set suitable version bounds for the plugins
   build-depends:
-    base >= 4.14 && < 4.16,
+    base >= 4.14 && < 4.18,
     clash-prelude >= 1.6 && < 1.10,
-    containers >= 0.6 && < 0.7,
+    containers >= 0.6 && < 0.8,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
@@ -105,18 +105,21 @@ library
     VexRiscv.ClockTicks
     VexRiscv.FFI
     VexRiscv.TH
+    VexRiscv.VecToTuple
+
   build-depends:
     base,
+    bytestring >= 0.10 && < 0.13,
     clash-prelude,
     clash-protocols,
-    bytestring >= 0.10 && < 0.11,
-    process >= 1.6 && < 1.8,
+    containers,
     directory >= 1.3 && < 1.4,
     filepath,
-    containers,
-    string-interpolate,
-    template-haskell,
     Glob,
+    process >= 1.6 && < 1.8,
+    string-interpolate,
+    tagged,
+    template-haskell,
   extra-libraries: VexRiscvFFI, stdc++
   include-dirs: src/
 
@@ -134,9 +137,9 @@ test-suite unittests
     base,
     clash-vexriscv,
     bytestring,
-    hedgehog >= 1.0 && < 1.1,
-    tasty >= 1.4 && < 1.5,
-    tasty-hedgehog >= 1.2 && < 1.3,
+    hedgehog >= 1.0 && < 1.5,
+    tasty >= 1.4 && < 1.6,
+    tasty-hedgehog >= 1.2 && < 1.5,
     tasty-hunit,
     tasty-th,
     template-haskell,

--- a/clash-vexriscv/src/VexRiscv.hs
+++ b/clash-vexriscv/src/VexRiscv.hs
@@ -25,6 +25,7 @@ import Language.Haskell.TH.Syntax
 import Protocols.Wishbone
 import VexRiscv.FFI
 import VexRiscv.TH
+import VexRiscv.VecToTuple
 
 
 data Input = Input
@@ -282,39 +283,37 @@ vexRiscv# !_sourcePath !_clk rst0
     let
       primName = 'vexRiscv#
       ( _
-       :> srcPath
-       :> clk
-       :> rst
-       :> timerInterrupt
-       :> externalInterrupt
-       :> softwareInterrupt
-       :> iBus_ACK
-       :> iBus_ERR
-       :> iBus_DAT_MISO
-       :> dBus_ACK
-       :> dBus_ERR
-       :> dBus_DAT_MISO
-       :> Nil
-       ) = indicesI @13
+       , srcPath
+       , clk
+       , rst
+       , timerInterrupt
+       , externalInterrupt
+       , softwareInterrupt
+       , iBus_ACK
+       , iBus_ERR
+       , iBus_DAT_MISO
+       , dBus_ACK
+       , dBus_ERR
+       , dBus_DAT_MISO
+       ) = vecToTuple (indicesI @13)
 
       ( iBus_CYC
-       :> iBus_STB
-       :> iBus_WE
-       :> iBus_ADR
-       :> iBus_DAT_MOSI
-       :> iBus_SEL
-       :> iBus_CTI
-       :> iBus_BTE
-       :> dBus_CYC
-       :> dBus_STB
-       :> dBus_WE
-       :> dBus_ADR
-       :> dBus_DAT_MOSI
-       :> dBus_SEL
-       :> dBus_CTI
-       :> dBus_BTE
-       :> Nil
-       ) = (\x -> extend @_ @16 @13 x + 1) <$> indicesI @16
+       , iBus_STB
+       , iBus_WE
+       , iBus_ADR
+       , iBus_DAT_MOSI
+       , iBus_SEL
+       , iBus_CTI
+       , iBus_BTE
+       , dBus_CYC
+       , dBus_STB
+       , dBus_WE
+       , dBus_ADR
+       , dBus_DAT_MOSI
+       , dBus_SEL
+       , dBus_CTI
+       , dBus_BTE
+       ) = vecToTuple $ (\x -> extend @_ @16 @13 x + 1) <$> indicesI @16
 
       cpu = extend @_ @_ @1 dBus_BTE + 1
     in

--- a/clash-vexriscv/src/VexRiscv/VecToTuple.hs
+++ b/clash-vexriscv/src/VexRiscv/VecToTuple.hs
@@ -1,0 +1,279 @@
+-- SPDX-FileCopyrightText: 2022-2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+
+-- Purpose of this module
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module VexRiscv.VecToTuple (VecToTuple(..)) where
+
+import Clash.Prelude
+
+import Data.Tagged (Tagged(..))
+
+#if MIN_VERSION_base(4,16,0)
+import Data.Tuple (Solo(Solo))
+#endif
+
+class VecToTuple a where
+  type TupType a = r | r -> a
+  vecToTuple ::  a -> TupType a
+
+-- | Silly instance
+instance VecToTuple (Vec 0 a) where
+  type TupType (Vec 0 a) = Tagged a ()
+  vecToTuple Nil = Tagged ()
+
+#if MIN_VERSION_base(4,16,0)
+instance VecToTuple (Vec 1 a) where
+  type TupType (Vec 1 a) = Solo a
+  vecToTuple (a0 :> Nil) = Solo a0
+#endif
+
+instance VecToTuple (Vec 2 a) where
+  type TupType (Vec 2 a) = (a, a)
+  vecToTuple (a0 :> a1 :> Nil) = (a0, a1)
+
+instance VecToTuple (Vec 3 a) where
+  type TupType (Vec 3 a) = (a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> Nil) = (a0, a1, a2)
+
+instance VecToTuple (Vec 4 a) where
+  type TupType (Vec 4 a) = (a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> Nil) = (a0, a1, a2, a3)
+
+instance VecToTuple (Vec 5 a) where
+  type TupType (Vec 5 a) = (a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> Nil) = (a0, a1, a2, a3, a4)
+
+instance VecToTuple (Vec 6 a) where
+  type TupType (Vec 6 a) = (a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> Nil) = (a0, a1, a2, a3, a4, a5)
+
+instance VecToTuple (Vec 7 a) where
+  type TupType (Vec 7 a) = (a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> Nil) = (a0, a1, a2, a3, a4, a5, a6)
+
+instance VecToTuple (Vec 8 a) where
+  type TupType (Vec 8 a) = (a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7)
+
+instance VecToTuple (Vec 9 a) where
+  type TupType (Vec 9 a) = (a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8)
+
+instance VecToTuple (Vec 10 a) where
+  type TupType (Vec 10 a) = (a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
+
+instance VecToTuple (Vec 11 a) where
+  type TupType (Vec 11 a) = (a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+
+instance VecToTuple (Vec 12 a) where
+  type TupType (Vec 12 a) = (a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)
+
+instance VecToTuple (Vec 13 a) where
+  type TupType (Vec 13 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+
+instance VecToTuple (Vec 14 a) where
+  type TupType (Vec 14 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
+
+instance VecToTuple (Vec 15 a) where
+  type TupType (Vec 15 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)
+
+instance VecToTuple (Vec 16 a) where
+  type TupType (Vec 16 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
+
+instance VecToTuple (Vec 17 a) where
+  type TupType (Vec 17 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)
+
+instance VecToTuple (Vec 18 a) where
+  type TupType (Vec 18 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)
+
+instance VecToTuple (Vec 19 a) where
+  type TupType (Vec 19 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)
+
+instance VecToTuple (Vec 20 a) where
+  type TupType (Vec 20 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)
+
+instance VecToTuple (Vec 21 a) where
+  type TupType (Vec 21 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
+
+instance VecToTuple (Vec 22 a) where
+  type TupType (Vec 22 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)
+
+instance VecToTuple (Vec 23 a) where
+  type TupType (Vec 23 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22)
+
+instance VecToTuple (Vec 24 a) where
+  type TupType (Vec 24 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23)
+
+instance VecToTuple (Vec 25 a) where
+  type TupType (Vec 25 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24)
+
+instance VecToTuple (Vec 26 a) where
+  type TupType (Vec 26 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
+
+instance VecToTuple (Vec 27 a) where
+  type TupType (Vec 27 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26)
+
+instance VecToTuple (Vec 28 a) where
+  type TupType (Vec 28 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27)
+
+instance VecToTuple (Vec 29 a) where
+  type TupType (Vec 29 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28)
+
+instance VecToTuple (Vec 30 a) where
+  type TupType (Vec 30 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29)
+
+instance VecToTuple (Vec 31 a) where
+  type TupType (Vec 31 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30)
+
+instance VecToTuple (Vec 32 a) where
+  type TupType (Vec 32 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31)
+
+instance VecToTuple (Vec 33 a) where
+  type TupType (Vec 33 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32)
+
+instance VecToTuple (Vec 34 a) where
+  type TupType (Vec 34 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33)
+
+instance VecToTuple (Vec 35 a) where
+  type TupType (Vec 35 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34)
+
+instance VecToTuple (Vec 36 a) where
+  type TupType (Vec 36 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35)
+
+instance VecToTuple (Vec 37 a) where
+  type TupType (Vec 37 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36)
+
+instance VecToTuple (Vec 38 a) where
+  type TupType (Vec 38 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37)
+
+instance VecToTuple (Vec 39 a) where
+  type TupType (Vec 39 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38)
+
+instance VecToTuple (Vec 40 a) where
+  type TupType (Vec 40 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39)
+
+instance VecToTuple (Vec 41 a) where
+  type TupType (Vec 41 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40)
+
+instance VecToTuple (Vec 42 a) where
+  type TupType (Vec 42 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41)
+
+instance VecToTuple (Vec 43 a) where
+  type TupType (Vec 43 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42)
+
+instance VecToTuple (Vec 44 a) where
+  type TupType (Vec 44 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43)
+
+instance VecToTuple (Vec 45 a) where
+  type TupType (Vec 45 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44)
+
+instance VecToTuple (Vec 46 a) where
+  type TupType (Vec 46 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45)
+
+instance VecToTuple (Vec 47 a) where
+  type TupType (Vec 47 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46)
+
+instance VecToTuple (Vec 48 a) where
+  type TupType (Vec 48 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47)
+
+instance VecToTuple (Vec 49 a) where
+  type TupType (Vec 49 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48)
+
+instance VecToTuple (Vec 50 a) where
+  type TupType (Vec 50 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49)
+
+instance VecToTuple (Vec 51 a) where
+  type TupType (Vec 51 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50)
+
+instance VecToTuple (Vec 52 a) where
+  type TupType (Vec 52 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51)
+
+instance VecToTuple (Vec 53 a) where
+  type TupType (Vec 53 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52)
+
+instance VecToTuple (Vec 54 a) where
+  type TupType (Vec 54 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53)
+
+instance VecToTuple (Vec 55 a) where
+  type TupType (Vec 55 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54)
+
+instance VecToTuple (Vec 56 a) where
+  type TupType (Vec 56 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55)
+
+instance VecToTuple (Vec 57 a) where
+  type TupType (Vec 57 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56)
+
+instance VecToTuple (Vec 58 a) where
+  type TupType (Vec 58 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57)
+
+instance VecToTuple (Vec 59 a) where
+  type TupType (Vec 59 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> a58 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58)
+
+instance VecToTuple (Vec 60 a) where
+  type TupType (Vec 60 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> a58 :> a59 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59)
+
+instance VecToTuple (Vec 61 a) where
+  type TupType (Vec 61 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> a58 :> a59 :> a60 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60)
+
+instance VecToTuple (Vec 62 a) where
+  type TupType (Vec 62 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> a58 :> a59 :> a60 :> a61 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61)

--- a/clash-vexriscv/tests/unittests/Tests/VexRiscv/ClockTicks.hs
+++ b/clash-vexriscv/tests/unittests/Tests/VexRiscv/ClockTicks.hs
@@ -2,7 +2,6 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE NoMonoLocalBinds #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -7,7 +7,6 @@ let
   rust_overlay = import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
   overlay = _: nixpkgs: {
     # Nix tooling
-    niv = (import sources.niv {}).niv;
     gitignore = import sources.gitignore { inherit (nixpkgs) lib; };
     openocd-vexriscv = import ./openocd-vexriscv.nix { inherit (nixpkgs) pkgs; };
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,22 +5,22 @@
         "homepage": "",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
-        "sha256": "07vg2i9va38zbld9abs9lzqblz193vc5wvqd6h7amkmwf66ljcgh",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "sha256": "1rlja3ba9s1n0icy3aarwhx9hk1jyfgngzizbn1afwwdlpvdlqw0",
         "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore.nix/archive/a20de23b925fd8264fd7fad6454652e142fd7f73.tar.gz",
+        "url": "https://github.com/hercules-ci/gitignore.nix/archive/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-22.11",
+        "branch": "nixos-23.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c54d842d9544361aac5f5b212ba04e4089e8efe",
-        "sha256": "14hk2lyxy8ajczn77363vw05w24fyx9889q3b89riqgs28acyz87",
+        "rev": "5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b",
+        "sha256": "0zjwk71lsri9zmlmhwgz1ny9dv91kaznii2wjff4g2d3w47gy8nj",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8c54d842d9544361aac5f5b212ba04e4089e8efe.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -7,14 +7,18 @@ pkgs.mkShell {
   name = "shell";
   buildInputs =
     [
-      pkgs.cabal-install
       pkgs.gcc
-      pkgs.haskell.compiler.ghc90
       pkgs.pkg-config
       pkgs.sbt
       pkgs.scala
       pkgs.verilator
 
+      # Haskell toolchain
+      pkgs.cabal-install
+      # pkgs.haskell.compiler.ghc90
+      # pkgs.haskell.compiler.ghc92
+      pkgs.haskell.compiler.ghc94
+      # pkgs.haskell.compiler.ghc96
 
       (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
 

--- a/shell.nix
+++ b/shell.nix
@@ -7,13 +7,14 @@ pkgs.mkShell {
   name = "shell";
   buildInputs =
     [
-      pkgs.buildPackages.cabal-install
-      pkgs.buildPackages.gcc
-      pkgs.buildPackages.ghc
-      pkgs.buildPackages.pkg-config
-      pkgs.buildPackages.sbt
-      pkgs.buildPackages.scala
-      pkgs.buildPackages.verilator
+      pkgs.cabal-install
+      pkgs.gcc
+      pkgs.haskell.compiler.ghc90
+      pkgs.pkg-config
+      pkgs.sbt
+      pkgs.scala
+      pkgs.verilator
+
 
       (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
 
@@ -21,7 +22,18 @@ pkgs.mkShell {
       pkgs.openocd-vexriscv
 
       # For Cabal to clone git repos
-      pkgs.buildPackages.git
+      pkgs.git
+
+      # For upgrading Nix env. To update dependencies (within bounds of the currently
+      # tracking NixOS version) use:
+      #
+      #   niv update
+      #
+      # If you want to upgrade nixpkgs to another NixOS version, use:
+      #
+      #   niv update nixpkgs -b nixos-23.11
+      #
+      pkgs.niv
     ]
     ;
 


### PR DESCRIPTION
I've left 9.6 out, as it is affected by the issues reported in https://github.com/clash-lang/clash-compiler/pull/2665.

~~We should maybe upstream `VecToTuple` in the future.~~ [The future is now.](https://github.com/clash-lang/clash-compiler/pull/2682)