### PR TITLE
Prevent Rust from constant folding in FPU test

### DIFF
--- a/clash-vexriscv-sim/test-programs/src/bin/fpu_test.rs
+++ b/clash-vexriscv-sim/test-programs/src/bin/fpu_test.rs
@@ -36,17 +36,23 @@ impl core::fmt::Write for PrintAddr {
 fn main() -> ! {
     let mut addr = PrintAddr;
 
+    // The compiler is smart enough to constant fold the following floating
+    // point operations, so we put the values around a black box.
+    // That makes it so that the compiler is "blind" to the values and
+    // generates the actual instructions
+    let b = core::hint::black_box;
+
     print("This test makes sure the FPU works as expected\n");
 
     #[allow(clippy::unnecessary_cast)]
     let _ = writeln!(addr, "79823i32 as f32 = {}", 79823i32 as f32);
 
-    let _ = writeln!(addr, "1.3 + 5.3 = {}", 1.3f32 + 5.3f32);
-    let _ = writeln!(addr, "5.3 - 1.3 = {}", 5.3f32 - 1.3f32);
+    let _ = writeln!(addr, "1.3 + 5.3 = {}", b(1.3f32) + b(5.3f32));
+    let _ = writeln!(addr, "5.3 - 1.3 = {}", b(5.3f32) - b(1.3f32));
 
-    let _ = writeln!(addr, "24.65 * 43.2 = {}", 24.65f32 * 43.2f32);
+    let _ = writeln!(addr, "24.65 * 43.2 = {}", b(24.65f32) * b(43.2f32));
 
-    let _ = writeln!(addr, "12.6 / 4.2 = {}", 12.6f32 / 4.2f32);
+    let _ = writeln!(addr, "12.6 / 4.2 = {}", b(12.6f32) / b(4.2f32));
 
     loop {
         continue;


### PR DESCRIPTION
The operations were done at compile time, so the floating point operations didn't end up in the binary - even debug ones!

This commit wraps all the relevant floating point values in a `black_box` which prevents the compiler from "seeing" the values, so it emits proper FPU instructions in all cases.

fixes #21