### PR TITLE
Generate random values for undefineds when pokeing

### DIFF
--- a/clash-vexriscv-sim/src/Utils/Cpu.hs
+++ b/clash-vexriscv-sim/src/Utils/Cpu.hs
@@ -106,8 +106,8 @@ cpu jtagPort bootIMem bootDMem =
             { timerInterrupt = low,
               externalInterrupt = low,
               softwareInterrupt = low,
-              iBusWbS2M = makeDefined iBus,
-              dBusWbS2M = makeDefined dBus
+              iBusWbS2M = iBus,
+              dBusWbS2M = dBus
             }
       )
         <$> iS2M

--- a/clash-vexriscv/clash-vexriscv.cabal
+++ b/clash-vexriscv/clash-vexriscv.cabal
@@ -112,6 +112,7 @@ library
     VexRiscv.ClockTicks
     VexRiscv.FFI
     VexRiscv.JtagTcpBridge
+    VexRiscv.Random
     VexRiscv.TH
     VexRiscv.VecToTuple
 
@@ -126,6 +127,7 @@ library
     Glob,
     network,
     process >= 1.6 && < 1.8,
+    random,
     string-interpolate,
     tagged,
     template-haskell,
@@ -141,9 +143,11 @@ test-suite unittests
   other-modules:
     Tests.Extra
     Tests.VexRiscv.ClockTicks
+    Tests.VexRiscv.Random
   build-depends:
     HUnit,
     base,
+    clash-prelude-hedgehog,
     clash-vexriscv,
     bytestring,
     hedgehog >= 1.0 && < 1.5,

--- a/clash-vexriscv/src/VexRiscv/Random.hs
+++ b/clash-vexriscv/src/VexRiscv/Random.hs
@@ -1,0 +1,52 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE CPP #-}
+
+module VexRiscv.Random where
+
+import Clash.Prelude
+
+-- See https://github.com/clash-lang/clash-compiler/issues/2707
+#if __GLASGOW_HASKELL__ < 902
+import Numeric.Natural
+#endif
+
+import Clash.Sized.Internal.BitVector
+import Data.Bifunctor (bimap)
+import GHC.IO (unsafePerformIO)
+import System.Random
+
+-- | Unsafe version of 'makeDefinedRandom' with a NOINLINE pragma to avoid
+-- compiler optimizations.
+unsafeMakeDefinedRandom :: DefinedRandom a => a -> a
+unsafeMakeDefinedRandom = unsafePerformIO . makeDefinedRandom
+{-# NOINLINE unsafeMakeDefinedRandom #-}
+
+-- | A class for types that can be (partially) undefined whose undefined values
+-- can be replaced with defined random values.
+class DefinedRandom a where
+  makeDefinedRandom :: a -> IO a
+
+instance DefinedRandom Bool where
+  makeDefinedRandom b
+    | hasUndefined b = randomIO
+    | otherwise = pure b
+
+instance DefinedRandom Bit where
+  makeDefinedRandom b
+    | hasUndefined b = Bit 0 <$> randomRIO (0, 1)
+    | otherwise = pure b
+
+instance KnownNat n => DefinedRandom (BitVector n) where
+  makeDefinedRandom :: KnownNat n => BitVector n -> IO (BitVector n)
+  makeDefinedRandom bv@(ensureSpine -> BV mask dat)
+    | mask == 0 = pure bv
+    | otherwise =  do
+    let maxVal = natToNum @(2^n - 1)
+    randomInt <- genNatural (0, fromIntegral maxVal)
+    pure $ BV 0 (((maxVal `xor` mask) .&. dat) .|. (mask .&. randomInt))
+
+-- | Generate a random natural number in the given inclusive range.
+genNatural :: (Natural, Natural) -> IO Natural
+genNatural = fmap fromInteger . randomRIO . bimap toInteger toInteger

--- a/clash-vexriscv/tests/unittests/Tests/VexRiscv/Random.hs
+++ b/clash-vexriscv/tests/unittests/Tests/VexRiscv/Random.hs
@@ -1,0 +1,44 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Tests.VexRiscv.Random where
+
+import Clash.Prelude
+
+import Clash.Hedgehog.Sized.BitVector
+import Hedgehog
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import VexRiscv.Random
+
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+tests :: TestTree
+tests = testGroup "VexRiscv.Random"
+  [ testProperty "genNatural" prop_genNatural
+  , testProperty "makeDefinedRandomBitVector" prop_makeDefinedRandomBitVector
+  , testProperty "makeDefinedRandomBit" prop_makeDefinedRandomBit
+  ]
+
+prop_genNatural :: Property
+prop_genNatural = property $ do
+  lo <- forAll $ Gen.integral (Range.linear 0 (shiftL 1 1024))
+  hi <- forAll $ Gen.integral (Range.linear lo (shiftL 1 1024))
+  n <- evalIO $ genNatural (lo, hi)
+  assert ((n >= lo) && (n <= hi))
+
+prop_makeDefinedRandomBitVector :: Property
+prop_makeDefinedRandomBitVector = property $ do
+  someBv <- forAll $ (genSomeBitVector @_ @0) (Range.linear 0 1024) genBitVector
+  case someBv of
+    SomeBitVector SNat bv -> do
+      definedBv <- evalIO $ makeDefinedRandom bv
+      assert (not $ hasUndefined definedBv)
+      assert (definedBv <= maxBound)
+
+prop_makeDefinedRandomBit :: Property
+prop_makeDefinedRandomBit = property $ do
+  b <- forAll $ genBit
+  definedB <- evalIO $ makeDefinedRandom b
+  assert (not $ hasUndefined definedB)

--- a/clash-vexriscv/tests/unittests/main.hs
+++ b/clash-vexriscv/tests/unittests/main.hs
@@ -10,10 +10,12 @@ import Test.Tasty
 import Test.Tasty.Hedgehog
 
 import qualified Tests.VexRiscv.ClockTicks
+import qualified Tests.VexRiscv.Random
 
 tests :: TestTree
 tests = testGroup "Tests"
   [ Tests.VexRiscv.ClockTicks.tests
+  , Tests.VexRiscv.Random.tests
   ]
 
 setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit


### PR DESCRIPTION
The current FFI implementation does not handle undefined values.
This PR changes the storable instances of the inputs to vexrisc such that `poke` checks if a value has undefined bits.
If the value has undefined bits we generate a random value.

Do note that partially undefined values will get completely new randomized values. At the moment I'm not sure how to best implement this, I'm open for suggestions or discussion.