### PR TITLE
Switch `Fwd` and `Bwd` to make `M`/`S` relation consistent

### DIFF
--- a/clash-vexriscv/src/VexRiscv.hs
+++ b/clash-vexriscv/src/VexRiscv.hs
@@ -68,8 +68,8 @@ data CpuOut = CpuOut
 data Jtag (dom :: Domain)
 
 instance Protocol (Jtag dom) where
-  type Fwd (Jtag dom) = Signal dom JtagOut
-  type Bwd (Jtag dom) = Signal dom JtagIn
+  type Fwd (Jtag dom) = Signal dom JtagIn
+  type Bwd (Jtag dom) = Signal dom JtagOut
 
 
 -- When passing S2M values from Haskell to VexRiscv over the FFI, undefined


### PR DESCRIPTION
All protocols in `clash-protocols` follow the convention that if a circuit is formed as `Circuit a ()` it is a subordinate, and when it is formed as `Circuit () a`, it is a manager instead. This commit aligns the `Jtag` protocol in a similar way.