### PR TITLE
Bump SBT to `1.10.1`

### DIFF
--- a/clash-vexriscv/example-cpu/project/build.properties
+++ b/clash-vexriscv/example-cpu/project/build.properties
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-sbt.version=1.7.1
+sbt.version=1.10.1


### PR DESCRIPTION
SBT 1.10.1 uses non-broken Scala