### PR TITLE
Move `ndmreset` and `stoptime` from `JtagOut` to `CpuOut`

### DIFF
--- a/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
@@ -76,7 +76,7 @@ getRunOpts = RunOpts
     )
 
 jtagDaisyChain :: JtagIn -> JtagOut -> JtagIn
-jtagDaisyChain (JtagIn tc ms _) (JtagOut to _ _) = JtagIn tc ms to
+jtagDaisyChain (JtagIn tc ms _) (JtagOut to) = JtagIn tc ms to
 
 type CpuSignals =
   ( CpuOut
@@ -117,11 +117,6 @@ main = do
           (circ, jto, writes1, iBus, dBus) = cpu NoDumpVcd (Just jtagInB) iMemB dMemB
           dBus' = register emptyWishboneS2M dBus
         in bundle (circ, jto, writes1, iBus, dBus')
-
-    _jtagReset = L.foldl (liftA2 go1) (pure False) [jtagOutA, jtagOutB]
-     where
-      go1 acc (JtagOut _ _ tr) = acc || bitToBool tr
-
     cpuOut = bundle (cpuOutA, cpuOutB)
 
   runSampling

--- a/clash-vexriscv-sim/src/Utils/Cpu.hs
+++ b/clash-vexriscv-sim/src/Utils/Cpu.hs
@@ -61,11 +61,11 @@ cpu dumpVcd jtagIn0 bootIMem bootDMem =
   , dS2M
   )
   where
-    (cpuOut, jtagOut) = vexRiscv dumpVcd hasClock (hasReset `unsafeOrReset` jtagReset) input jtagIn1
+    (cpuOut, jtagOut) = vexRiscv dumpVcd hasClock (hasReset `unsafeOrReset` ndmReset) input jtagIn1
 
-    jtagReset =
+    ndmReset =
       unsafeFromActiveHigh $ register False $
-        bitToBool . ndmreset <$> jtagOut
+        bitToBool . ndmreset <$> cpuOut
 
     jtagIn1 = fromMaybe (pure JTag.defaultIn) jtagIn0
 

--- a/clash-vexriscv/src/VexRiscv/FFI.hsc
+++ b/clash-vexriscv/src/VexRiscv/FFI.hsc
@@ -79,8 +79,9 @@ data OUTPUT = OUTPUT
   , dBusWishbone_CTI :: Word8
   , dBusWishbone_BTE :: Word8
 
-  , jtag_ndmreset :: Bit
-  , jtag_stoptime :: Bit
+  , ndmreset :: Bit
+  , stoptime :: Bit
+
   , jtag_TDO :: Bit
   }
   deriving (Show)
@@ -93,9 +94,7 @@ data JTAG_INPUT = JTAG_INPUT
   deriving (Show)
 
 data JTAG_OUTPUT = JTAG_OUTPUT
-  { ndmreset :: Bit
-  , stoptime :: Bit
-  , tdo :: Bit
+  { tdo :: Bit
   }
   deriving (Show)
 
@@ -176,8 +175,9 @@ instance Storable OUTPUT where
       <*> (#peek OUTPUT, dBusWishbone_CTI) ptr
       <*> (#peek OUTPUT, dBusWishbone_BTE) ptr
 
-      <*> (#peek OUTPUT, jtag_ndmreset) ptr
-      <*> (#peek OUTPUT, jtag_stoptime) ptr
+      <*> (#peek OUTPUT, ndmreset) ptr
+      <*> (#peek OUTPUT, stoptime) ptr
+
       <*> (#peek OUTPUT, jtag_TDO) ptr
 
     {-# INLINE poke #-}
@@ -200,8 +200,9 @@ instance Storable OUTPUT where
       (#poke OUTPUT, dBusWishbone_CTI) ptr (dBusWishbone_CTI this)
       (#poke OUTPUT, dBusWishbone_BTE) ptr (dBusWishbone_BTE this)
 
-      (#poke OUTPUT, jtag_ndmreset) ptr (jtag_ndmreset this)
-      (#poke OUTPUT, jtag_stoptime) ptr (jtag_stoptime this)
+      (#poke OUTPUT, ndmreset) ptr (ndmreset this)
+      (#poke OUTPUT, stoptime) ptr (stoptime this)
+
       (#poke OUTPUT, jtag_TDO) ptr (jtag_TDO this)
       return ()
 
@@ -210,13 +211,10 @@ instance Storable JTAG_OUTPUT where
     sizeOf _ = #size JTAG_OUTPUT
     {-# INLINE peek #-}
     peek ptr = const JTAG_OUTPUT <$> pure ()
-      <*> (#peek JTAG_OUTPUT, ndmreset) ptr
-      <*> (#peek JTAG_OUTPUT, stoptime) ptr
       <*> (#peek JTAG_OUTPUT, tdo) ptr
 
     {-# INLINE poke #-}
     poke ptr this = do
-      (#poke JTAG_OUTPUT, ndmreset) ptr (ndmreset this)
       (#poke JTAG_OUTPUT, tdo) ptr (tdo this)
 
 instance Storable JTAG_INPUT where

--- a/clash-vexriscv/src/VexRiscv/JtagTcpBridge.hs
+++ b/clash-vexriscv/src/VexRiscv/JtagTcpBridge.hs
@@ -42,7 +42,7 @@ vexrJtagBridge' port = do
         shutDown = vexrJtagBridgeShutdown bridge
 
         step JtagOut{..} = alloca $ \outFFI -> alloca $ \inFFI -> do
-            poke outFFI (JTAG_OUTPUT ndmreset stoptime testDataOut)
+            poke outFFI (JTAG_OUTPUT testDataOut)
             vexrJtagBridgeStep bridge outFFI inFFI
             JTAG_INPUT{..} <- peek inFFI
             let input = JtagIn { testClock = tck, testModeSelect = tms, testDataIn = tdi }

--- a/clash-vexriscv/src/ffi/impl.cpp
+++ b/clash-vexriscv/src/ffi/impl.cpp
@@ -114,8 +114,8 @@ void set_outputs(VVexRiscv *top, OUTPUT *output) {
   output->dBusWishbone_CTI = top->dBusWishbone_CTI;
   output->dBusWishbone_BTE = top->dBusWishbone_BTE;
 
-  output->jtag_ndmreset = top->ndmreset;
-  output->jtag_stoptime = top->stoptime;
+  output->ndmreset = top->ndmreset;
+  output->stoptime = top->stoptime;
   output->jtag_TDO = top->jtag_tdo;
 }
 

--- a/clash-vexriscv/src/ffi/interface.h
+++ b/clash-vexriscv/src/ffi/interface.h
@@ -49,8 +49,8 @@ typedef struct {
   uint8_t dBusWishbone_CTI;
   uint8_t dBusWishbone_BTE;
 
-  bit jtag_ndmreset;
-  bit jtag_stoptime;
+  bit ndmreset;
+  bit stoptime;
   bit jtag_TDO;
 } OUTPUT;
 
@@ -61,8 +61,6 @@ typedef struct {
 } JTAG_INPUT;
 
 typedef struct {
-  bit ndmreset;
-  bit stoptime;
   bit tdo;
 } JTAG_OUTPUT;
 


### PR DESCRIPTION
These signals are not related to the jtag protocol