### PR TITLE
Bump OpenOCD

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -20,13 +20,17 @@ RUN apt-get update \
 
 FROM builder AS build-openocd-riscv
 
-ARG DEPS_OPENOCD_VEXRISCV="autoconf automake libtool pkg-config libusb-1.0-0-dev libftdi-dev libhidapi-dev libusb-dev libyaml-dev"
+ARG DEPS_RISCV_OPENOCD="autoconf automake libtool pkg-config libusb-1.0-0-dev libftdi-dev libhidapi-dev libusb-dev libyaml-dev libjim-dev"
 
+# See note in 'nix/openocd-riscv.nix' on forked riscv-openocd. Though it is a
+# Nix workaround, we clone the same repo here to make sure Docker and Nix do
+# the same thing.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends $DEPS_OPENOCD_VEXRISCV \
-  && git clone --recursive https://github.com/SpinalHDL/openocd_riscv.git \
-  && cd openocd_riscv \
-  && ./bootstrap \
+  && apt-get install -y --no-install-recommends $DEPS_RISCV_OPENOCD \
+  && git clone --recursive https://github.com/martijnbastiaan/riscv-openocd.git \
+  && cd riscv-openocd \
+  && git checkout no-submodules-ea8f9d51954b979ff6b4d90afa70352763199b63 \
+  && SKIP_SUBMODULE=1 ./bootstrap \
   && ./configure --enable-ftdi --enable-dummy --prefix=/opt \
   && make -j$(nproc) \
   && make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           - "9.6.6"
 
     container:
-      image: ghcr.io/clash-lang/clash-vexriscv-ci:${{ matrix.ghc }}-20250110
+      image: ghcr.io/clash-lang/clash-vexriscv-ci:${{ matrix.ghc }}-20250211
 
     steps:
       - name: Checkout

--- a/nix/openocd-riscv.nix
+++ b/nix/openocd-riscv.nix
@@ -11,6 +11,7 @@ pkgs.stdenv.mkDerivation rec {
     pkgs.automake
     pkgs.coreutils
     pkgs.git
+    pkgs.jimtcl
     pkgs.libtool
     pkgs.libusb1
     pkgs.libyaml
@@ -20,15 +21,12 @@ pkgs.stdenv.mkDerivation rec {
   ];
 
   src = pkgs.fetchgit {
-    url = "https://github.com/riscv-collab/riscv-openocd";
-    rev = "ea8f9d51954b979ff6b4d90afa70352763199b63";
-    sha256 = "sha256-cc4OebtCCsZyaMIlTfpUe26MwZ8WnrFt+IYQ+B2Hzww=";
-    fetchSubmodules = true;
-    deepClone = true;
-    postFetch = ''
-      # See: https://github.com/NixOS/nixpkgs/issues/8567#issuecomment-1846499599
-      find "$out/" -type d -name '.git' -exec rm -rf {} ';'
-    '';
+    # Upstream repo (riscv-collab/riscv-openocd) contains submodules, which Nix can't
+    # reliably hash. My fork removes the submodules (and provides a script to build new
+    # submodule free branches).
+    url = "https://github.com/martijnbastiaan/riscv-openocd";
+    rev = "refs/heads/no-submodules-ea8f9d51954b979ff6b4d90afa70352763199b63";
+    sha256 = "sha256-5atDDeh06Z07b4Bd5WssEOiGIDmoO08OXpwtrmRdoBQ=";
   };
 
   installPhase = ''


### PR DESCRIPTION
* Use `openocd-vexriscv` on CI
* Use latest HEAD of OpenOCD
* Switch to submodule-less repository to work around Nix issues