### PR TITLE
Add test for vexriscv reset behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - run: nix-shell --run "cabal build all"
       - run: nix-shell --run "cabal run clash-vexriscv:unittests"
-      - run: nix-shell --run "cabal run clash-vexriscv-sim:unittests -- -j1"
+      - run: nix-shell --run "cabal run clash-vexriscv-sim:unittests -- -j1 --jtag-debug"
       - run: nix-shell --run "cabal run clash-vexriscv-sim:hdl-test"
 
   license-check:
@@ -266,7 +266,7 @@ jobs:
       - name: Run `clash-vexriscv-sim` unittests
         run: |
           # Can't run the unit tests with multiple threads because of the common use of port 7894.
-          cabal run clash-vexriscv-sim:unittests -- -j1
+          cabal run clash-vexriscv-sim:unittests -- -j1 --jtag-debug
 
       - name: Run `clash-vexriscv-sim` HDL test
         run: |

--- a/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
@@ -48,8 +48,8 @@ data RunOpts = RunOpts
   , b_execPath :: FilePath
   , a_logPath :: FilePath
   , b_logPath :: FilePath
-  , a_keepInReset :: Maybe Int
-  , b_keepInReset :: Maybe Int
+  , a_assertResetFor :: Maybe Int
+  , b_assertResetFor :: Maybe Int
   }
 
 getRunOpts :: Parser RunOpts
@@ -78,15 +78,15 @@ getRunOpts =
     <*> optional
       ( option
           auto
-          ( long "keep-cpu-a-in-reset"
-              <> help "Keep CPU A in reset"
+          ( long "assert-cpu-a-reset-for"
+              <> help "Assert CPU A in reset for N cycles"
           )
       )
     <*> optional
       ( option
           auto
-          ( long "keep-cpu-b-in-reset"
-              <> help "Keep CPU B in reset"
+          ( long "assert-cpu-b-reset-for"
+              <> help "Assert CPU B in reset for N cycles"
           )
       )
 
@@ -127,7 +127,7 @@ main = do
 
   let
     jtagInA = jtagBridge jtagOutB
-    resetA = toReset a_keepInReset
+    resetA = toReset a_assertResetFor
     cpuOutA@(unbundle -> (_circuitA, jtagOutA, _, _iBusA, _dBusA)) =
       withClock @System clockGen
         $ withReset @System resetA
@@ -135,7 +135,7 @@ main = do
            in bundle (circ, jto, writes1, iBus, dBus)
 
     jtagInB = liftA2 jtagDaisyChain jtagInA jtagOutA
-    resetB = toReset b_keepInReset
+    resetB = toReset b_assertResetFor
     cpuOutB@(unbundle -> (_circuitB, jtagOutB, _, _iBusB, _dBusB)) =
       withClock @System clockGen
         $ withReset @System resetB

--- a/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
@@ -44,12 +44,12 @@ debugConfig =
 --------------------------------------
 
 data RunOpts = RunOpts
-  { execPathA :: FilePath
-  , execPathB :: FilePath
-  , logPathA :: FilePath
-  , logPathB :: FilePath
-  , keepInResetA :: Maybe Int
-  , keepInResetB :: Maybe Int
+  { a_execPath :: FilePath
+  , b_execPath :: FilePath
+  , a_logPath :: FilePath
+  , b_logPath :: FilePath
+  , a_keepInReset :: Maybe Int
+  , b_keepInReset :: Maybe Int
   }
 
 getRunOpts :: Parser RunOpts
@@ -111,14 +111,14 @@ main = do
 
   (iMemA, dMemA) <-
     withClockResetEnable @System clockGen resetGen enableGen
-      $ loadProgramDmem @System execPathA
+      $ loadProgramDmem @System a_execPath
 
   (iMemB, dMemB) <-
     withClockResetEnable @System clockGen resetGen enableGen
-      $ loadProgramDmem @System execPathB
+      $ loadProgramDmem @System b_execPath
 
-  logFileA <- openFile logPathA WriteMode
-  logFileB <- openFile logPathB WriteMode
+  logFileA <- openFile a_logPath WriteMode
+  logFileB <- openFile b_logPath WriteMode
 
   let portNr = 7894
   jtagBridge <- vexrJtagBridge portNr
@@ -127,7 +127,7 @@ main = do
 
   let
     jtagInA = jtagBridge jtagOutB
-    resetA = toReset keepInResetA
+    resetA = toReset a_keepInReset
     cpuOutA@(unbundle -> (_circuitA, jtagOutA, _, _iBusA, _dBusA)) =
       withClock @System clockGen
         $ withReset @System resetA
@@ -135,7 +135,7 @@ main = do
            in bundle (circ, jto, writes1, iBus, dBus)
 
     jtagInB = liftA2 jtagDaisyChain jtagInA jtagOutA
-    resetB = toReset keepInResetB
+    resetB = toReset b_keepInReset
     cpuOutB@(unbundle -> (_circuitB, jtagOutB, _, _iBusB, _dBusB)) =
       withClock @System clockGen
         $ withReset @System resetB

--- a/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
@@ -10,7 +10,7 @@ import Clash.Prelude
 import Control.Monad (forM_, when)
 import GHC.Char (chr)
 import GHC.IO.Handle (Handle, hFlush, hPutStr)
-import Options.Applicative (Parser, execParser, fullDesc, header, help, helper, info, long, progDesc, short, strOption, option, auto)
+import Options.Applicative (Parser, auto, execParser, fullDesc, header, help, helper, info, long, option, progDesc, short, strOption)
 import Protocols.Wishbone
 import System.Exit (exitFailure)
 import System.IO (IOMode (WriteMode), hPutChar, hPutStrLn, openFile, stdout)
@@ -101,7 +101,7 @@ type CpuSignals =
   , WishboneS2M (BitVector 32)
   )
 
-toReset :: KnownDomain dom => Maybe Int -> Reset dom
+toReset :: (KnownDomain dom) => Maybe Int -> Reset dom
 toReset Nothing = resetGenN d2
 toReset (Just n) = unsafeFromActiveHigh $ fromList (L.replicate n True <> L.repeat False)
 

--- a/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
@@ -10,7 +10,7 @@ import Clash.Prelude
 import Control.Monad (forM_, when)
 import GHC.Char (chr)
 import GHC.IO.Handle (Handle, hFlush, hPutStr)
-import Options.Applicative (Parser, execParser, fullDesc, header, help, helper, info, long, progDesc, short, strOption, switch)
+import Options.Applicative (Parser, execParser, fullDesc, header, help, helper, info, long, progDesc, short, strOption, option, auto)
 import Protocols.Wishbone
 import System.Exit (exitFailure)
 import System.IO (IOMode (WriteMode), hPutChar, hPutStrLn, openFile, stdout)
@@ -48,8 +48,8 @@ data RunOpts = RunOpts
   , execPathB :: FilePath
   , logPathA :: FilePath
   , logPathB :: FilePath
-  , keepInResetA :: Bool
-  , keepInResetB :: Bool
+  , keepInResetA :: Maybe Int
+  , keepInResetB :: Maybe Int
   }
 
 getRunOpts :: Parser RunOpts
@@ -75,13 +75,19 @@ getRunOpts =
           <> long "b-log"
           <> help "Path to the log file for CPU B"
       )
-    <*> switch
-      ( long "keep-cpu-a-in-reset"
-          <> help "Keep CPU A in reset"
+    <*> optional
+      ( option
+          auto
+          ( long "keep-cpu-a-in-reset"
+              <> help "Keep CPU A in reset"
+          )
       )
-    <*> switch
-      ( long "keep-cpu-b-in-reset"
-          <> help "Keep CPU B in reset"
+    <*> optional
+      ( option
+          auto
+          ( long "keep-cpu-b-in-reset"
+              <> help "Keep CPU B in reset"
+          )
       )
 
 jtagDaisyChain :: JtagIn -> JtagOut -> JtagIn
@@ -94,6 +100,10 @@ type CpuSignals =
   , WishboneS2M (BitVector 32)
   , WishboneS2M (BitVector 32)
   )
+
+toReset :: KnownDomain dom => Maybe Int -> Reset dom
+toReset Nothing = resetGenN d2
+toReset (Just n) = unsafeFromActiveHigh $ fromList (L.replicate n True <> L.repeat False)
 
 main :: IO ()
 main = do
@@ -117,9 +127,7 @@ main = do
 
   let
     jtagInA = jtagBridge jtagOutB
-    resetA
-      | keepInResetA = unsafeFromActiveHigh (pure True)
-      | otherwise = resetGenN d2
+    resetA = toReset keepInResetA
     cpuOutA@(unbundle -> (_circuitA, jtagOutA, _, _iBusA, _dBusA)) =
       withClock @System clockGen
         $ withReset @System resetA
@@ -127,9 +135,7 @@ main = do
            in bundle (circ, jto, writes1, iBus, dBus)
 
     jtagInB = liftA2 jtagDaisyChain jtagInA jtagOutA
-    resetB
-      | keepInResetB = unsafeFromActiveHigh (pure True)
-      | otherwise = resetGenN d2
+    resetB = toReset keepInResetB
     cpuOutB@(unbundle -> (_circuitB, jtagOutB, _, _iBusB, _dBusB)) =
       withClock @System clockGen
         $ withReset @System resetB

--- a/clash-vexriscv-sim/data/vexriscv_chain_gdbb.cfg
+++ b/clash-vexriscv-sim/data/vexriscv_chain_gdbb.cfg
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-# Assume "print_a" is running on the CPU
+# Assume "print_b" is running on the CPU
 file "target/riscv32imc-unknown-none-elf/debug/print_b"
 
 # Work around issues where simulation is too slow to respond to keep-alive messages,
@@ -27,7 +27,7 @@ break main
 # Jump to start address, should run until it hits main
 jump _start
 
-# Run until we hit function "done", meaning it should have printed "a"
+# Run until we hit function "done", meaning it should have printed "b"
 disable 1
 break print_b::done
 continue
@@ -37,7 +37,7 @@ disable 2
 file "target/riscv32imc-unknown-none-elf/debug/print_a"
 load
 
-# Jump to start address. Should now output "b".
+# Jump to start address. Should now output "a".
 break print_a::done
 jump _start
 

--- a/clash-vexriscv-sim/tests/Tests/Jtag.hs
+++ b/clash-vexriscv-sim/tests/Tests/Jtag.hs
@@ -143,8 +143,12 @@ test debug = do
   gdb <- getGdb
 
   let
-    -- Timeout after 60 seconds
+    -- Timeout after 60 seconds. Warning: removing the type signature breaks
+    -- stack traces.
+    expectLine :: HasCallStack => Bool -> Handle -> String -> Assertion
     expectLine = expectLineOrTimeout 60_000_000
+
+    waitForLine :: HasCallStack => Bool -> Handle -> String -> Assertion
     waitForLine = waitForLineOrTimeout 60_000_000
 
     vexRiscvProc =

--- a/clash-vexriscv-sim/tests/Tests/Jtag.hs
+++ b/clash-vexriscv-sim/tests/Tests/Jtag.hs
@@ -72,6 +72,8 @@ expectLineOrTimeout ::
   String ->
   Assertion
 expectLineOrTimeout us debug h expected = do
+  when debug $
+    hPutStrLn stderr (">>> Expecting: " <> expected)
   result <- timeout us go
   case result of
     Just () -> pure ()
@@ -81,7 +83,7 @@ expectLineOrTimeout us debug h expected = do
     line <- hGetLine h
 
     when debug $ do
-      hPutStr stderr "> "
+      hPutStr stderr (if line == expected then "[✓] " else "[ ] ")
       hPutStrLn stderr line
 
     ifM
@@ -101,6 +103,8 @@ waitForLineOrTimeout ::
   String ->
   Assertion
 waitForLineOrTimeout us debug h expected = do
+  when debug $
+    hPutStrLn stderr (">>> Waiting for: " <> expected)
   result <- timeout us go
   case result of
     Just () -> pure ()
@@ -109,7 +113,7 @@ waitForLineOrTimeout us debug h expected = do
   go = do
     line <- hGetLine h
     when debug $ do
-      hPutStr stderr "> "
+      hPutStr stderr (if line == expected then "[✓] " else "[ ] ")
       hPutStrLn stderr line
     if line == expected
       then pure ()

--- a/clash-vexriscv-sim/tests/Tests/Jtag.hs
+++ b/clash-vexriscv-sim/tests/Tests/Jtag.hs
@@ -60,6 +60,12 @@ getGdb = do
     Nothing -> fail "Neither gdb-multiarch nor gdb found in PATH"
     Just x -> pure x
 
+bold :: String -> String
+bold s = "\ESC[1m" <> s <> "\ESC[0m"
+
+green :: String -> String
+green s = "\ESC[32m" <> s <> "\ESC[0m"
+
 expectLineOrTimeout ::
   (HasCallStack) =>
   -- | Number of microseconds to wait. I.e., 1_000_000 is 1 second.
@@ -73,7 +79,7 @@ expectLineOrTimeout ::
   Assertion
 expectLineOrTimeout us debug h expected = do
   when debug $
-    hPutStrLn stderr (">>> Expecting: " <> expected)
+    hPutStrLn stderr (bold (">>> Expecting: " <> expected))
   result <- timeout us go
   case result of
     Just () -> pure ()
@@ -83,8 +89,10 @@ expectLineOrTimeout us debug h expected = do
     line <- hGetLine h
 
     when debug $ do
-      hPutStr stderr (if line == expected then "[✓] " else "[ ] ")
-      hPutStrLn stderr line
+      hPutStrLn stderr $
+        if line == expected
+          then bold $ green $ "[✓] " <> line
+          else "[ ] " <> line
 
     ifM
       (pure $ null line)
@@ -104,7 +112,7 @@ waitForLineOrTimeout ::
   Assertion
 waitForLineOrTimeout us debug h expected = do
   when debug $
-    hPutStrLn stderr (">>> Waiting for: " <> expected)
+    hPutStrLn stderr (bold (">>> Waiting for: " <> expected))
   result <- timeout us go
   case result of
     Just () -> pure ()
@@ -113,8 +121,10 @@ waitForLineOrTimeout us debug h expected = do
   go = do
     line <- hGetLine h
     when debug $ do
-      hPutStr stderr (if line == expected then "[✓] " else "[ ] ")
-      hPutStrLn stderr line
+      hPutStrLn stderr $
+        if line == expected
+          then bold $ green $ "[✓] " <> line
+          else "[ ] " <> line
     if line == expected
       then pure ()
       else go

--- a/clash-vexriscv-sim/tests/Tests/Jtag.hs
+++ b/clash-vexriscv-sim/tests/Tests/Jtag.hs
@@ -145,10 +145,10 @@ test debug = do
   let
     -- Timeout after 60 seconds. Warning: removing the type signature breaks
     -- stack traces.
-    expectLine :: HasCallStack => Bool -> Handle -> String -> Assertion
+    expectLine :: (HasCallStack) => Bool -> Handle -> String -> Assertion
     expectLine = expectLineOrTimeout 60_000_000
 
-    waitForLine :: HasCallStack => Bool -> Handle -> String -> Assertion
+    waitForLine :: (HasCallStack) => Bool -> Handle -> String -> Assertion
     waitForLine = waitForLineOrTimeout 60_000_000
 
     vexRiscvProc =
@@ -180,6 +180,7 @@ test debug = do
     withCreateProcess openOcdProc $ \_ _ (fromJust -> openOcdStdErr) _ -> do
       hSetBuffering openOcdStdErr LineBuffering
       putStrLn "Waiting for \"Halting processor\" on openOcdStdErr"
+      waitForLine debug openOcdStdErr "[riscv.cpu0] Target successfully examined."
       waitForLine debug openOcdStdErr "Halting processor"
 
       -- OpenOCD has started, so we can start GDB

--- a/clash-vexriscv-sim/tests/Tests/JtagChain.hs
+++ b/clash-vexriscv-sim/tests/Tests/JtagChain.hs
@@ -176,7 +176,7 @@ testInResetA debug = do
     waitForLine :: (HasCallStack) => Bool -> Handle -> String -> Assertion
     waitForLine = waitForLineOrTimeout 240_000_000
 
-  let vexRiscvProc1 = addArgs vexRiscvProc ["--keep-cpu-a-in-reset"]
+  let vexRiscvProc1 = addArgs vexRiscvProc ["--keep-cpu-a-in-reset", show (maxBound :: Int)]
 
   withStreamingFile logPathB $ \logB -> do
     withCreateProcess vexRiscvProc1 $ \_ (fromJust -> simStdOut) _ _ -> do

--- a/clash-vexriscv-sim/tests/Tests/JtagChain.hs
+++ b/clash-vexriscv-sim/tests/Tests/JtagChain.hs
@@ -176,7 +176,7 @@ testInResetA debug = do
     waitForLine :: (HasCallStack) => Bool -> Handle -> String -> Assertion
     waitForLine = waitForLineOrTimeout 240_000_000
 
-  let vexRiscvProc1 = addArgs vexRiscvProc ["--keep-cpu-a-in-reset", show (maxBound :: Int)]
+  let vexRiscvProc1 = addArgs vexRiscvProc ["--assert-cpu-a-reset-for", show (maxBound :: Int)]
 
   withStreamingFile logPathB $ \logB -> do
     withCreateProcess vexRiscvProc1 $ \_ (fromJust -> simStdOut) _ _ -> do
@@ -213,7 +213,7 @@ testResetDeassertion debug = do
     waitForLine :: (HasCallStack) => Bool -> Handle -> String -> Assertion
     waitForLine = waitForLineOrTimeout 120_000_000
 
-  let vexRiscvProc1 = addArgs vexRiscvProc ["--keep-cpu-a-in-reset", show @Int 50_000]
+  let vexRiscvProc1 = addArgs vexRiscvProc ["--assert-cpu-a-reset-for", show @Int 50_000]
 
   withStreamingFiles (logPathA :> logPathB :> Nil) $ \(vecToTuple -> (logA, logB)) -> do
     withCreateProcess vexRiscvProc1 $ \_ (fromJust -> simStdOut) _ _ -> do

--- a/clash-vexriscv-sim/tests/Tests/JtagChain.hs
+++ b/clash-vexriscv-sim/tests/Tests/JtagChain.hs
@@ -10,14 +10,14 @@ import Clash.Prelude (KnownNat, Vec (Nil, (:>)), toList)
 import Clash.Sized.Vector (unsafeFromList)
 import Clash.Sized.Vector.ToTuple (vecToTuple)
 
-import Control.Monad.Extra (unlessM)
+import Control.Monad.Extra (unlessM, when)
 import Data.Data (Proxy (Proxy))
 import Data.Maybe (fromJust)
 import GHC.Stack (HasCallStack)
 import System.Directory (doesPathExist)
 import System.Exit (ExitCode (ExitSuccess))
 import System.FilePath ((</>))
-import System.IO (Handle, IOMode (WriteMode), withFile)
+import System.IO (Handle, IOMode (WriteMode), hPutStrLn, stderr, withFile)
 import System.Process
 import Test.Tasty (TestTree, askOption, defaultIngredients, defaultMainWithIngredients, includingOptions, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@=?))
@@ -118,6 +118,7 @@ testBoth debug = do
 
   withStreamingFiles (logPathA :> logPathB :> Nil) $ \(vecToTuple -> (logA, logB)) -> do
     withCreateProcess vexRiscvProc $ \_ (fromJust -> simStdOut) _ _ -> do
+      when debug $ hPutStrLn stderr ""
       waitForLine debug simStdOut "JTAG bridge ready at port 7894"
 
       expectLine debug logA "[CPU] a"
@@ -180,6 +181,7 @@ testInResetA debug = do
 
   withStreamingFile logPathB $ \logB -> do
     withCreateProcess vexRiscvProc1 $ \_ (fromJust -> simStdOut) _ _ -> do
+      when debug $ hPutStrLn stderr ""
       waitForLine debug simStdOut "JTAG bridge ready at port 7894"
 
       expectLine debug logB "[CPU] b"
@@ -217,6 +219,7 @@ testResetDeassertion debug = do
 
   withStreamingFiles (logPathA :> logPathB :> Nil) $ \(vecToTuple -> (logA, logB)) -> do
     withCreateProcess vexRiscvProc1 $ \_ (fromJust -> simStdOut) _ _ -> do
+      when debug $ hPutStrLn stderr ""
       waitForLine debug simStdOut "JTAG bridge ready at port 7894"
 
       expectLine debug logB "[CPU] b" -- first load

--- a/clash-vexriscv-sim/tests/Tests/JtagChain.hs
+++ b/clash-vexriscv-sim/tests/Tests/JtagChain.hs
@@ -33,7 +33,7 @@ getSimulateExecPath = cabalListBin "clash-vexriscv-sim:clash-vexriscv-chain-bin"
 getProjectRoot :: IO FilePath
 getProjectRoot = findParentContaining cabalProject
 
-data Args = Args
+data TestContext = TestContext
   { vexRiscvProc :: CreateProcess
   , openOcdProc :: CreateProcess
   , gdbProcA :: CreateProcess
@@ -42,8 +42,8 @@ data Args = Args
   , logPathB :: FilePath
   }
 
-createArgs :: IO Args
-createArgs = do
+createTestContext :: IO TestContext
+createTestContext = do
   simulateExecPath <- getSimulateExecPath
   projectRoot <- getProjectRoot
   gdb <- getGdb
@@ -90,7 +90,7 @@ createArgs = do
   ensureExists logPathB
 
   pure $
-    Args
+    TestContext
       { vexRiscvProc
       , openOcdProc
       , gdbProcA
@@ -114,7 +114,7 @@ testBoth debug = do
     waitForLine :: (HasCallStack) => Bool -> Handle -> String -> Assertion
     waitForLine = waitForLineOrTimeout 120_000_000
 
-  Args{vexRiscvProc, openOcdProc, gdbProcA, gdbProcB, logPathA, logPathB} <- createArgs
+  TestContext{vexRiscvProc, openOcdProc, gdbProcA, gdbProcB, logPathA, logPathB} <- createTestContext
 
   withStreamingFiles (logPathA :> logPathB :> Nil) $ \(vecToTuple -> (logA, logB)) -> do
     withCreateProcess vexRiscvProc $ \_ (fromJust -> simStdOut) _ _ -> do
@@ -165,7 +165,7 @@ testInResetA ::
   Bool ->
   Assertion
 testInResetA debug = do
-  Args{vexRiscvProc, openOcdProc, gdbProcB, logPathB} <- createArgs
+  TestContext{vexRiscvProc, openOcdProc, gdbProcB, logPathB} <- createTestContext
 
   let
     -- Timeout after 240 seconds. These tests are extremely slow, because a lot
@@ -208,7 +208,7 @@ testResetDeassertion ::
   Bool ->
   Assertion
 testResetDeassertion debug = do
-  Args{vexRiscvProc, openOcdProc, gdbProcB, gdbProcA, logPathA, logPathB} <- createArgs
+  TestContext{vexRiscvProc, openOcdProc, gdbProcB, gdbProcA, logPathA, logPathB} <- createTestContext
 
   let
     -- Timeout after 120 seconds. Warning: removing the type signature breaks
@@ -256,7 +256,7 @@ testResetAssertion ::
   Bool ->
   Assertion
 testResetAssertion debug = do
-  Args{vexRiscvProc, openOcdProc, gdbProcA, gdbProcB, logPathA, logPathB} <- createArgs
+  TestContext{vexRiscvProc, openOcdProc, gdbProcA, gdbProcB, logPathA, logPathB} <- createTestContext
 
   let
     -- Timeout after 120 seconds. Warning: removing the type signature breaks

--- a/clash-vexriscv-sim/tests/Tests/JtagChain.hs
+++ b/clash-vexriscv-sim/tests/Tests/JtagChain.hs
@@ -56,8 +56,12 @@ test debug = do
   ensureExists logBPath
 
   let
-    -- Timeout after 120 seconds
+    -- Timeout after 120 seconds. Warning: removing the type signature breaks
+    -- stack traces.
+    expectLine :: HasCallStack => Bool -> Handle -> String -> Assertion
     expectLine = expectLineOrTimeout 120_000_000
+
+    waitForLine :: HasCallStack => Bool -> Handle -> String -> Assertion
     waitForLine = waitForLineOrTimeout 120_000_000
 
     vexRiscvProc =


### PR DESCRIPTION
Adds two tests:

- Whether we can keep one CPU in reset and talk to the other one just fine
- Whether we can keep one CPU in reset, talk to the other one, _deassert_ the reset, and talk to the first one.

There is also a test that tests whether we can assert the reset while GDB is doing things and expect it to recover... but it can't reliably. I've disabled the test with an `-- XXX: ....` in hopes we can find a way to properly recover in the future.