### PR TITLE
Remove enable from `cpu`

### DIFF
--- a/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
@@ -108,13 +108,15 @@ main = do
   let
     jtagInA = jtagBridge jtagOutB
     cpuOutA@(unbundle -> (_circuitA, jtagOutA, _, _iBusA, _dBusA)) =
-      withClockResetEnable @System clockGen (resetGenN (SNat @2)) enableGen
+      withClock @System clockGen
+        $ withReset @System (resetGenN (SNat @2))
         $ let (circ, jto, writes1, iBus, dBus) = cpu NoDumpVcd (Just jtagInA) iMemA dMemA
            in bundle (circ, jto, writes1, iBus, dBus)
 
     jtagInB = liftA2 jtagDaisyChain jtagInA jtagOutA
     cpuOutB@(unbundle -> (_circuitB, jtagOutB, _, _iBusB, _dBusB)) =
-      withClockResetEnable @System clockGen (resetGenN (SNat @2)) enableGen
+      withClock @System clockGen
+        $ withReset @System (resetGenN (SNat @2))
         $ let (circ, jto, writes1, iBus, dBus) = cpu NoDumpVcd (Just jtagInB) iMemB dMemB
            in bundle (circ, jto, writes1, iBus, dBus)
     cpuOut = bundle (cpuOutA, cpuOutB)

--- a/clash-vexriscv-sim/src/Utils/Interconnect.hs
+++ b/clash-vexriscv-sim/src/Utils/Interconnect.hs
@@ -16,7 +16,6 @@ import Protocols.Wishbone
   of the input and output vectors are the same.
 -}
 interconnectTwo ::
-  (HiddenClockResetEnable dom) =>
   Signal dom (WishboneM2S 32 4 (BitVector 32)) ->
   -- | sorted by address
   Vec 2 (BitVector 32, Signal dom (WishboneS2M (BitVector 32))) ->


### PR DESCRIPTION
It is confusing: the vexriscv does not have an enable. I also don't see a good reason for having enables _just_ for the memories.