### PR TITLE
Check whether Nix shell works on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,51 @@ on: [push]
 # That file determines which version gets used locally on developer machines.
 
 jobs:
+  nix-shell:
+    name: VexRiscv integration (Nix shell)
+    needs: [rust-build-programs]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+
+      - name: Enter Nix shell
+        run: |
+          nix-shell --run "echo 'Nix shell entered'"
+
+      - name: Update Cabal index info
+        run: |
+          cp .github/cabal.project cabal.project.local
+          nix-shell --run "cabal update"
+          nix-shell --run "cabal freeze"
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/state/cabal/store/
+            ~/.cabal/store
+          key: packages-cachebust-3-nix-${{ hashFiles('cabal.project.freeze', 'cabal.project', 'shell.nix', 'nix/**/*.nix', 'nix/**/*.json') }}
+          restore-keys: packages-cachebust-3-nix
+
+      - name: Download VexRiscv Integration Tests
+        uses: actions/download-artifact@v4
+        with:
+          name: vexriscv-test-binaries
+
+      - name: Extract VexRiscv Integration Tests
+        run: |
+          tar -x -f vexriscv-test-binaries.tar
+
+      - run: nix-shell --run "cabal build all"
+      - run: nix-shell --run "cabal run clash-vexriscv:unittests"
+      - run: nix-shell --run "cabal run clash-vexriscv-sim:unittests -- -j1"
+      - run: nix-shell --run "cabal run clash-vexriscv-sim:hdl-test"
+
   license-check:
     runs-on: ubuntu-22.04
     container:
@@ -233,7 +278,8 @@ jobs:
         'license-check',
         'rust-checks',
         'vex-riscv',
-        'rust-build-programs'
+        'rust-build-programs',
+        'nix-shell'
       ]
     runs-on: ubuntu-22.04
     steps:

--- a/nix/openocd-riscv.nix
+++ b/nix/openocd-riscv.nix
@@ -26,7 +26,7 @@ pkgs.stdenv.mkDerivation rec {
     # submodule free branches).
     url = "https://github.com/martijnbastiaan/riscv-openocd";
     rev = "refs/heads/no-submodules-ea8f9d51954b979ff6b4d90afa70352763199b63";
-    sha256 = "sha256-5atDDeh06Z07b4Bd5WssEOiGIDmoO08OXpwtrmRdoBQ=";
+    sha256 = "sha256-9UmjCCvAWIUoczqqTtgEmoHSTcKLSbG3nLrPgwz1m9o=";
   };
 
   installPhase = ''


### PR DESCRIPTION
I accidentally used a broken hash. Unfortunately, it existed on my local system, so Nix didn't complain. Opening it on another machine did confront me. This commit adds Nix to CI.