### PR TITLE
Use `tail` instead of `streaming` to follow files

### DIFF
--- a/clash-vexriscv-sim/clash-vexriscv-sim.cabal
+++ b/clash-vexriscv-sim/clash-vexriscv-sim.cabal
@@ -174,7 +174,6 @@ test-suite unittests
     extra,
     filepath,
     process,
-    streaming,
     tasty >= 1.2 && < 1.6,
     tasty-hunit >= 0.10 && < 0.11,
     temporary >=1.1 && <1.4,


### PR DESCRIPTION
For the chaining test we're using log files to separate out the print statements from the two CPUs. We couldn't re-use the `expectLine` / `waitForLine` from the non-chaining tests, because when it reached EOF these functions would throw an error. To work around that, we opted to use `streaming`. However, this turned out to have two problems:

 1. It implements its "wait for more output" mechanism as a spin lock. The tests therefore hog 100% of the CPU.

 2. When it doesn't see more output, it starts using more and more memory. For some reason, when the file is closed entirely it starts using more memory at a very rapid pace, quickly exhausting the host's memory.

To ditch `streaming`, this commit switches reading the log using UNIX's `tail` instead. This behaves as expected: cpu usage  as well as memory usage of the unit tests themselves have dropped to near-zero.