### PR TITLE
Improve debugability by adding call stacks / timeouts to expect functions

### DIFF
--- a/clash-vexriscv-sim/tests/Tests/Jtag.hs
+++ b/clash-vexriscv-sim/tests/Tests/Jtag.hs
@@ -10,6 +10,7 @@ import Control.Monad.Extra (ifM, when)
 import Data.List.Extra (trim)
 import Data.Maybe (fromJust)
 import Data.Proxy
+import GHC.Stack (callStack, prettyCallStack)
 import System.Directory (findExecutable)
 import System.Exit
 import System.IO
@@ -57,7 +58,7 @@ getGdb = do
     Nothing -> fail "Neither gdb-multiarch nor gdb found in PATH"
     Just x -> pure x
 
-expectLine :: Bool -> Handle -> String -> Assertion
+expectLine :: (HasCallStack) => Bool -> Handle -> String -> Assertion
 expectLine debug h expected = do
   line <- hGetLine h
   when debug $ do
@@ -66,9 +67,9 @@ expectLine debug h expected = do
   ifM
     (pure $ null line)
     (expectLine debug h expected)
-    (expected @?= line)
+    (assertEqual (prettyCallStack callStack) expected line)
 
-waitForLine :: Bool -> Handle -> String -> IO ()
+waitForLine :: (HasCallStack) => Bool -> Handle -> String -> IO ()
 waitForLine debug h expected = do
   line <- hGetLine h
   when debug $ do

--- a/clash-vexriscv-sim/tests/Tests/JtagChain.hs
+++ b/clash-vexriscv-sim/tests/Tests/JtagChain.hs
@@ -1,6 +1,7 @@
 -- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NumericUnderscores #-}
 
 module Tests.JtagChain where
 
@@ -22,7 +23,7 @@ import Test.Tasty.HUnit (Assertion, testCase, (@=?))
 import Test.Tasty.Options (OptionDescription (Option))
 import Prelude
 
-import Tests.Jtag (JtagDebug (JtagDebug), cabalListBin, expectLine, getGdb, waitForLine)
+import Tests.Jtag (JtagDebug (JtagDebug), cabalListBin, expectLineOrTimeout, getGdb, waitForLineOrTimeout)
 import Utils.FilePath (BuildType (Debug), cabalProject, findParentContaining, rustBinsDir)
 
 getSimulateExecPath :: IO FilePath
@@ -55,6 +56,10 @@ test debug = do
   ensureExists logBPath
 
   let
+    -- Timeout after 120 seconds
+    expectLine = expectLineOrTimeout 120_000_000
+    waitForLine = waitForLineOrTimeout 120_000_000
+
     vexRiscvProc =
       ( proc
           simulateExecPath

--- a/clash-vexriscv-sim/tests/Tests/JtagChain.hs
+++ b/clash-vexriscv-sim/tests/Tests/JtagChain.hs
@@ -32,6 +32,7 @@ getProjectRoot :: IO FilePath
 getProjectRoot = findParentContaining cabalProject
 
 test ::
+  (HasCallStack) =>
   -- | Print debug output of subprocesses
   Bool ->
   Assertion
@@ -120,7 +121,7 @@ ensureExists path = unlessM (doesPathExist path) (withFile path WriteMode (\_ ->
 errorHelper :: (HasCallStack) => String -> String -> m a
 errorHelper expected found = error ("expected `" <> expected <> "`, found `" <> found <> "`")
 
-tests :: TestTree
+tests :: (HasCallStack) => TestTree
 tests = askOption $ \(JtagDebug debug) ->
   testGroup
     "JTAG chaining"


### PR DESCRIPTION
Example unexpected line error:

```
FAIL (2.67s)
      tests/Tests/Jtag.hs:143:
      CallStack (from HasCallStack):
        expectLineOrTimeout, called at tests/Tests/Jtag.hs:143:18 in main:Tests.Jtag
      expected: "[CPU] fooooo"
       but got: "[CPU] a"
```

Example timeout error:

```
FAIL (3.73s)
      tests/Tests/Jtag.hs:120:
      Timed out waiting for Halting processor
      
      CallStack (from HasCallStack):
        waitForLineOrTimeout, called at tests/Tests/Jtag.hs:144:19 in main:Tests.Jtag
```