### PR TITLE
Add support for GHC 9.8 and 9.10, drop support for 9.0 and 9.4

### DIFF
--- a/.github/docker/build-and-publish-docker-image.sh
+++ b/.github/docker/build-and-publish-docker-image.sh
@@ -17,7 +17,7 @@ elif [[ "$1" != "" ]]; then
 fi
 
 UBUNTU_VERSION=jammy-20240125
-GHC_VERSIONS=( "9.10.1"  "9.8.4"  "9.6.6"  "9.4.7"  "9.0.2")
+GHC_VERSIONS=( "9.10.1"  "9.8.4"  "9.6.6")
 CABAL_VERSION="3.12.1.0"
 
 for i in "${!GHC_VERSIONS[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           path: |
             ~/.cabal-nix/store
-          key: packages-cachebust-3-nix-${{ hashFiles('cabal.project.freeze', 'cabal.project', 'shell.nix', 'nix/**/*.nix', 'nix/**/*.json') }}
-          restore-keys: packages-cachebust-3-nix
+          key: packages-cachebust-4-nix-${{ hashFiles('cabal.project.freeze', 'cabal.project', 'shell.nix', 'nix/**/*.nix', 'nix/**/*.json') }}
+          restore-keys: packages-cachebust-4-nix
 
       - name: Download VexRiscv Integration Tests
         uses: actions/download-artifact@v4
@@ -204,9 +204,9 @@ jobs:
       fail-fast: false
       matrix:
         ghc:
-          - "9.0.2"
-          - "9.4.7"
           - "9.6.6"
+          - "9.8.4"
+          - "9.10.1"
 
     container:
       image: ghcr.io/clash-lang/clash-vexriscv-ci:${{ matrix.ghc }}-20250211
@@ -225,8 +225,8 @@ jobs:
         with:
           path: |
             ~/.local/state/cabal/store/
-          key: packages-cachebust-3-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-${{ matrix.ghc }}
+          key: packages-cachebust-4-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
+          restore-keys: packages-cachebust-4-${{ matrix.ghc }}
 
       - name: Stash existing VexRiscv.v
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -16,33 +16,26 @@ package clash-prelude
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2023-09-28T08:48:26Z
--- index-state: 2025-01-10T11:37:42Z
+index-state: 2025-04-30T07:38:32Z
 
 -- Needed to simulate dynamic clocks.
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 6f9b7300da535bae01da67eeac99dd82f2cac965
+  tag: 4384800decf44ba51fc1fd083ff69691f0350ba1
   subdir: clash-prelude
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 6f9b7300da535bae01da67eeac99dd82f2cac965
+  tag: 4384800decf44ba51fc1fd083ff69691f0350ba1
   subdir: clash-ghc
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 6f9b7300da535bae01da67eeac99dd82f2cac965
+  tag: 4384800decf44ba51fc1fd083ff69691f0350ba1
   subdir: clash-lib
-
-source-repository-package
-  type: git
-  location: https://github.com/clash-lang/clash-compiler.git
-  tag: 6f9b7300da535bae01da67eeac99dd82f2cac965
-  subdir: clash-cores
 
 source-repository-package
   type: git
@@ -52,17 +45,22 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/clash-lang/clash-cores.git
+  tag: 200f6384d87f92947adb99d1a0a25abb4dd6f815
+
+source-repository-package
+  type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: 0832a422e77422739401896f6612620d17baa289
+  tag: a40880ca77f40f2b7c2b3400623fce0c063db47e
   subdir: clash-protocols
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: 0832a422e77422739401896f6612620d17baa289
+  tag: a40880ca77f40f2b7c2b3400623fce0c063db47e
   subdir: clash-protocols-base
 
 source-repository-package
   type: git
   location: https://github.com/cchalmers/circuit-notation.git
-  tag: 19b386c4aa3ff690758ae089c7754303f3500cc9
+  tag: 564769c52aa05b90f81bbc898b7af7087d96613d

--- a/cabal.project
+++ b/cabal.project
@@ -23,25 +23,11 @@ source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
   tag: 4384800decf44ba51fc1fd083ff69691f0350ba1
-  subdir: clash-prelude
-
-source-repository-package
-  type: git
-  location: https://github.com/clash-lang/clash-compiler.git
-  tag: 4384800decf44ba51fc1fd083ff69691f0350ba1
-  subdir: clash-ghc
-
-source-repository-package
-  type: git
-  location: https://github.com/clash-lang/clash-compiler.git
-  tag: 4384800decf44ba51fc1fd083ff69691f0350ba1
-  subdir: clash-lib
-
-source-repository-package
-  type: git
-  location: https://github.com/clash-lang/clash-compiler.git
-  tag: 6f9b7300da535bae01da67eeac99dd82f2cac965
-  subdir: clash-prelude-hedgehog
+  subdir:
+    clash-prelude
+    clash-lib
+    clash-ghc
+    clash-prelude-hedgehog
 
 source-repository-package
   type: git
@@ -52,13 +38,9 @@ source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
   tag: a40880ca77f40f2b7c2b3400623fce0c063db47e
-  subdir: clash-protocols
-
-source-repository-package
-  type: git
-  location: https://github.com/clash-lang/clash-protocols.git
-  tag: a40880ca77f40f2b7c2b3400623fce0c063db47e
-  subdir: clash-protocols-base
+  subdir:
+    clash-protocols
+    clash-protocols-base
 
 source-repository-package
   type: git

--- a/clash-vexriscv-sim/app/VexRiscvSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvSimulation.hs
@@ -44,7 +44,10 @@ debugConfig =
 
 main :: IO ()
 main = do
-  elfFile <- L.head <$> getArgs
+  args <- getArgs
+  let elfFile = case args of
+        [f] -> f
+        _ -> error "Usage: vexriscv-sim <elf-file>"
 
   (iMem, dMem) <-
     withClockResetEnable @System clockGen resetGen enableGen

--- a/clash-vexriscv-sim/clash-vexriscv-sim.cabal
+++ b/clash-vexriscv-sim/clash-vexriscv-sim.cabal
@@ -70,7 +70,7 @@ common common-options
     -fno-worker-wrapper
       -- clash-prelude will set suitable version bounds for the plugins
   build-depends:
-    base >= 4.14 && < 4.19,
+    base >= 4.16 && < 4.21,
     clash-prelude >= 1.9.0,
     containers >= 0.6 && < 0.8,
     ghc-typelits-natnormalise,

--- a/clash-vexriscv/clash-vexriscv.cabal
+++ b/clash-vexriscv/clash-vexriscv.cabal
@@ -94,7 +94,7 @@ common common-options
     -fno-worker-wrapper
       -- clash-prelude will set suitable version bounds for the plugins
   build-depends:
-    base >= 4.14 && < 4.19,
+    base >= 4.16 && < 4.21,
     clash-prelude >= 1.9.0,
     containers >= 0.6 && < 0.8,
     ghc-typelits-natnormalise,

--- a/clash-vexriscv/src/VexRiscv/ClockTicks.hs
+++ b/clash-vexriscv/src/VexRiscv/ClockTicks.hs
@@ -236,7 +236,7 @@ clockTicksEitherRelative ::
   [(Int64, ClockAB)]
 clockTicksEitherRelative clkA clkB = zip relativeTimestamps ticks
  where
-  relativeTimestamps = 0 : zipWith (-) (tail timestamps) timestamps
+  relativeTimestamps = 0 : zipWith (-) (drop 1 timestamps) timestamps
   (timestamps, ticks) = unzip (clockTicksEitherAbsolute clkA clkB)
 
 -- | Flip edge from rising to falling, and vice versa
@@ -353,7 +353,7 @@ clockEdgesEitherRelative ::
   [(Int64, ClockEdgeAB)]
 clockEdgesEitherRelative firstEdgeA firstEdgeB clkA clkB = zip relativeTimestamps ticks
  where
-  relativeTimestamps = 0 : zipWith (-) (tail timestamps) timestamps
+  relativeTimestamps = 0 : zipWith (-) (drop 1 timestamps) timestamps
   (timestamps, ticks) = unzip (clockEdgesEitherAbsolute firstEdgeA firstEdgeB clkA clkB)
 
 {- | Given the clock periods of a single clock, produce a list of clock edges
@@ -408,5 +408,5 @@ singleClockEdgesEitherRelative ::
   [(Int64, ActiveEdge)]
 singleClockEdgesEitherRelative firstEdge clk = zip relativeTimestamps edges
  where
-  relativeTimestamps = 0 : zipWith (-) (tail timestamps) timestamps
+  relativeTimestamps = 0 : zipWith (-) (drop 1 timestamps) timestamps
   (timestamps, edges) = unzip (singleClockEdgesEitherAbsolute firstEdge clk)

--- a/clash-vexriscv/tests/unittests/Tests/VexRiscv/ClockTicks.hs
+++ b/clash-vexriscv/tests/unittests/Tests/VexRiscv/ClockTicks.hs
@@ -118,7 +118,7 @@ relativeToAbsolute = snd . L.mapAccumL (\acc t -> let new = acc + t in (new, new
 -- | Convert a list of absolute event timestamps to a list of relative timestamps
 absoluteToRelative :: [Int64] -> [Int64]
 absoluteToRelative absoluteTimestamps =
-  0 : P.zipWith (-) (P.tail absoluteTimestamps) absoluteTimestamps
+  0 : P.zipWith (-) (P.drop 1 absoluteTimestamps) absoluteTimestamps
 
 unzipFirst :: ([a] -> [b]) -> [(a, c)] -> [(b, c)]
 unzipFirst f (P.unzip -> (as, cs)) = P.zip (f as) cs

--- a/clash-vexriscv/tests/unittests/Tests/VexRiscv/Random.hs
+++ b/clash-vexriscv/tests/unittests/Tests/VexRiscv/Random.hs
@@ -32,7 +32,7 @@ prop_genNatural = property $ do
 
 prop_makeDefinedRandomBitVector :: Property
 prop_makeDefinedRandomBitVector = property $ do
-  someBv <- forAll $ (genSomeBitVector @_ @0) (Range.linear 0 1024) genBitVector
+  someBv <- forAll $ (genSomeBitVector @0) (Range.linear 0 1024) genBitVector
   case someBv of
     SomeBitVector SNat bv -> do
       definedBv <- evalIO $ makeDefinedRandom bv

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-23.11",
+        "branch": "nixos-24.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b",
-        "sha256": "0zjwk71lsri9zmlmhwgz1ny9dv91kaznii2wjff4g2d3w47gy8nj",
+        "rev": "b000159bba69b0106a42f65e52dbf27f77aca9d3",
+        "sha256": "0d15jcfdw1z3d28gsjd8rixx4197qmvbpzhfq0xy9z5jvw82yh44",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b000159bba69b0106a42f65e52dbf27f77aca9d3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -16,12 +16,7 @@ pkgs.mkShell {
       # Haskell toolchain
       pkgs.cabal-install
       pkgs.haskellPackages.fourmolu
-
-      # pkgs.haskell.compiler.ghc90
-
-      # Clash throws a slow start warning / error on 9.4.8, so we use 9.4.7
-      pkgs.haskell.compiler.ghc947
-      # pkgs.haskell.compiler.ghc96
+      pkgs.ghc
 
       (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
 


### PR DESCRIPTION
We already had Docker images for 9.8/9.10, so that doesn't have to change.

I dropped 9.0/9.4 because `clash-cores` did (also we don't use it anymore).