### PR TITLE
split simulation utils into separate package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,7 @@ packages:
   clash-vexriscv/
   clash-vexriscv-example/
   clash-vexriscv-sim/
+  clash-vexriscv-sim-utils/
 
 write-ghc-environment-files: always
 tests: True
@@ -52,4 +53,3 @@ source-repository-package
   type: git
   location: https://github.com/clash-lang/ghc-typelits-natnormalise.git
   tag: a4fdc5bf17f678e74a47bf3b8924c6a35e214fb2
-

--- a/clash-vexriscv-sim-utils/LICENSE
+++ b/clash-vexriscv-sim-utils/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/clash-vexriscv-sim-utils/README.md
+++ b/clash-vexriscv-sim-utils/README.md
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2022 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Utilities for VexRiscv simulation in Haskell
+
+This package contains some building blocks to help with native Haskell simulation of VexRiscv cores such as
+
+- ways to load program binaries into memory images
+- a simple interconnect
+- a simple storage component

--- a/clash-vexriscv-sim-utils/clash-vexriscv-sim-utils.cabal
+++ b/clash-vexriscv-sim-utils/clash-vexriscv-sim-utils.cabal
@@ -1,22 +1,11 @@
 cabal-version:       3.8
-name:                clash-vexriscv-sim
+name:                clash-vexriscv-sim-utils
 version:             0.1
 License:             Apache-2.0
 license-file:        LICENSE
 author:              QBayLogic B.V.
 maintainer:          devops@qbaylogic.com
 Copyright:           Copyright © 2022 Google LLC
-build-type:          Custom
-
-extra-source-files:
-  data/*.Scala
-  data/*.cfg
-
-custom-setup
-  setup-depends:
-    base,
-    Cabal,
-    clash-vexriscv
 
 common common-options
   default-extensions:
@@ -91,104 +80,17 @@ library
   hs-source-dirs: src
   default-language: Haskell2010
   exposed-modules:
-    Utils.Cpu
-    Utils.DebugConfig
-    Utils.FilePath
-    Utils.Instance
-  other-modules:
-    VexRiscv_Example
-    VexRiscv_Example2
-  autogen-modules:
-    VexRiscv_Example
-    VexRiscv_Example2
+    VexRiscv.Sim.Utils.Interconnect
+    VexRiscv.Sim.Utils.ProgramLoad
+    VexRiscv.Sim.Utils.ReadElf
+    VexRiscv.Sim.Utils.Storage
   build-depends:
     base,
     bytestring >= 0.10 && < 0.13,
     clash-prelude,
     clash-protocols,
     clash-vexriscv,
-    clash-vexriscv-sim-utils,
     directory,
     elf >= 0.31 && < 0.32,
     filepath,
     template-haskell,
-
--- XXX: Doesn't really belong in clash-vexriscv-SIM
-executable hdl-test
-  import: common-options
-  main-is: app/HdlTest.hs
-  build-Depends:
-    base,
-    clash-ghc,
-    clash-vexriscv-sim,
-
-executable clash-vexriscv-bin
-  import: common-options
-  main-is: VexRiscvSimulation.hs
-  hs-source-dirs: app
-  default-language: Haskell2010
-  ghc-options: -threaded -rtsopts "-with-rtsopts=-M100M"
-  build-depends:
-    base,
-    clash-prelude,
-    clash-protocols,
-    clash-vexriscv,
-    clash-vexriscv-sim,
-    clash-vexriscv-sim-utils,
-    bytestring,
-    containers,
-    directory,
-
-executable clash-vexriscv-chain-bin
-  import: common-options
-  main-is: VexRiscvChainSimulation.hs
-  hs-source-dirs: app
-  default-language: Haskell2010
-  ghc-options: -threaded -rtsopts "-with-rtsopts=-M400M"
-  build-depends:
-    base,
-    clash-prelude,
-    clash-protocols,
-    clash-vexriscv,
-    clash-vexriscv-sim,
-    clash-vexriscv-sim-utils,
-    bytestring,
-    containers,
-    directory,
-    filepath,
-    optparse-applicative,
-
-test-suite unittests
-  import: common-options
-  default-language: Haskell2010
-  hs-source-dirs: tests
-  type: exitcode-stdio-1.0
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
-  build-tool-depends:
-    clash-vexriscv-sim:clash-vexriscv-bin,
-    clash-vexriscv-sim:clash-vexriscv-chain-bin
-  autogen-modules:
-    Paths_clash_vexriscv_sim
-  ghc-options: -threaded
-  main-is: tests.hs
-  other-modules:
-    Paths_clash_vexriscv_sim
-    Tests.Jtag
-    Tests.JtagChain
-  build-depends:
-    async,
-    base,
-    bytestring,
-    clash-prelude,
-    clash-protocols,
-    clash-vexriscv-sim,
-    clash-vexriscv-sim-utils,
-    clash-vexriscv,
-    containers,
-    directory,
-    extra,
-    filepath,
-    process,
-    tasty >= 1.2 && < 1.6,
-    tasty-hunit >= 0.10 && < 0.11,
-    temporary >=1.1 && <1.4,

--- a/clash-vexriscv-sim-utils/clash-vexriscv-sim-utils.cabal.license
+++ b/clash-vexriscv-sim-utils/clash-vexriscv-sim-utils.cabal.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 Google LLC
+
+SPDX-License-Identifier: CC0-1.0

--- a/clash-vexriscv-sim-utils/src/VexRiscv/Sim/Utils/Interconnect.hs
+++ b/clash-vexriscv-sim-utils/src/VexRiscv/Sim/Utils/Interconnect.hs
@@ -5,7 +5,7 @@
 -- GHC doesn't think exhaustive matches on Vectors are exhaustive..
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
-module Utils.Interconnect where
+module VexRiscv.Sim.Utils.Interconnect where
 
 import Clash.Prelude
 import Protocols.Wishbone

--- a/clash-vexriscv-sim-utils/src/VexRiscv/Sim/Utils/ProgramLoad.hs
+++ b/clash-vexriscv-sim-utils/src/VexRiscv/Sim/Utils/ProgramLoad.hs
@@ -3,7 +3,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE NumericUnderscores #-}
 
-module Utils.ProgramLoad where
+module VexRiscv.Sim.Utils.ProgramLoad where
 
 import Clash.Prelude
 import Control.Exception (assert)
@@ -13,8 +13,8 @@ import qualified Data.ByteString as BS
 import qualified Data.IntMap as I
 import qualified Data.List as L
 
-import Utils.ReadElf
-import Utils.Storage
+import VexRiscv.Sim.Utils.ReadElf
+import VexRiscv.Sim.Utils.Storage
 
 type DMemory dom =
   Signal dom (WishboneM2S 32 4) ->

--- a/clash-vexriscv-sim-utils/src/VexRiscv/Sim/Utils/ReadElf.hs
+++ b/clash-vexriscv-sim-utils/src/VexRiscv/Sim/Utils/ReadElf.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-module Utils.ReadElf (readElf, readElfFromMemory, Address, BinaryData) where
+module VexRiscv.Sim.Utils.ReadElf (readElf, readElfFromMemory, Address, BinaryData) where
 
 import Clash.Prelude
 import Data.Elf

--- a/clash-vexriscv-sim-utils/src/VexRiscv/Sim/Utils/Storage.hs
+++ b/clash-vexriscv-sim-utils/src/VexRiscv/Sim/Utils/Storage.hs
@@ -6,7 +6,7 @@
 -- it doesn't like lazy matching on `Signal`s it seems?
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
-module Utils.Storage (
+module VexRiscv.Sim.Utils.Storage (
   storage,
   dualPortStorage,
 ) where

--- a/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvChainSimulation.hs
@@ -17,12 +17,12 @@ import System.IO (IOMode (WriteMode), hPutChar, hPutStrLn, openFile, stdout)
 import Text.Printf (hPrintf, printf)
 import VexRiscv (CpuOut (dBusWbM2S, iBusWbM2S), DumpVcd (NoDumpVcd), JtagIn (JtagIn), JtagOut (JtagOut))
 import VexRiscv.JtagTcpBridge (vexrJtagBridge)
+import VexRiscv.Sim.Utils.ProgramLoad (loadProgramDmem)
 
 import qualified Data.List as L
 
 import Utils.Cpu (cpu)
 import Utils.DebugConfig (DebugConfiguration (..))
-import Utils.ProgramLoad (loadProgramDmem)
 
 -- change this variable to the configuration you want to use
 

--- a/clash-vexriscv-sim/app/VexRiscvSimulation.hs
+++ b/clash-vexriscv-sim/app/VexRiscvSimulation.hs
@@ -16,12 +16,12 @@ import System.IO (hFlush, putChar, stdout)
 import Text.Printf (printf)
 import VexRiscv (CpuOut (dBusWbM2S, iBusWbM2S), DumpVcd (NoDumpVcd))
 import VexRiscv.JtagTcpBridge (vexrJtagBridge)
+import VexRiscv.Sim.Utils.ProgramLoad (loadProgramDmem)
 
 import qualified Data.List as L
 
 import Utils.Cpu (cpu)
 import Utils.DebugConfig (DebugConfiguration (..))
-import Utils.ProgramLoad (loadProgramDmem)
 
 -- change this variable to the configuration you want to use
 

--- a/clash-vexriscv-sim/src/Utils/Cpu.hs
+++ b/clash-vexriscv-sim/src/Utils/Cpu.hs
@@ -18,8 +18,8 @@ import VexRiscv.JtagTcpBridge as JTag
 import VexRiscv.VecToTuple (vecToTuple)
 import VexRiscv_Example
 
-import Utils.Interconnect (interconnectTwo)
-import Utils.ProgramLoad (DMemory, Memory)
+import VexRiscv.Sim.Utils.Interconnect (interconnectTwo)
+import VexRiscv.Sim.Utils.ProgramLoad (DMemory, Memory)
 
 import qualified VexRiscv.Reset as MinReset
 

--- a/clash-vexriscv-sim/tests/tests.hs
+++ b/clash-vexriscv-sim/tests/tests.hs
@@ -19,12 +19,12 @@ import Test.Tasty
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 import Test.Tasty.Options
 import VexRiscv (DumpVcd (NoDumpVcd))
+import VexRiscv.Sim.Utils.ProgramLoad (loadProgramDmem)
 
 import qualified Data.ByteString as BS
 import qualified Data.List as L
 
 import Utils.Cpu (cpu)
-import Utils.ProgramLoad (loadProgramDmem)
 
 import qualified Tests.Jtag
 import qualified Tests.JtagChain


### PR DESCRIPTION
This splits the `clash-vexriscv-sim` package and creates a new `clash-vexriscv-sim-utils`.

This new package only contains utility functions that are not tied to any specific core.

This is important because `clash-vexriscv-sim` could not be used as an external dependency from cabal due to the custom build script and the Scala source files.

The new package should be able to be used as an external package so those simulation helpers can be reused.