### PR TITLE
Import `termToData` directly

### DIFF
--- a/clash-vexriscv/src/VexRiscv/BlackBox.hs
+++ b/clash-vexriscv/src/VexRiscv/BlackBox.hs
@@ -10,7 +10,7 @@ module VexRiscv.BlackBox where
 
 import Prelude
 
-import Clash.Core.TermLiteral (TermLiteral (termToData))
+import Clash.Core.TermLiteral (termToData)
 import Control.Monad.State (State)
 import Data.Either (lefts)
 import Data.List.Infinite (Infinite (..), (...))


### PR DESCRIPTION
After Clash 1.10, `termData` is no longer a method associated with `TermData`. Luckily, just importing `termData` directly works for both versions.